### PR TITLE
Fix fullwidth issues in editor

### DIFF
--- a/style.css
+++ b/style.css
@@ -295,8 +295,8 @@ body > .is-root-container,
 .wp-block-group.alignfull,
 .wp-block-group.has-background,
 .wp-block-cover.alignfull,
-.is-root-container .wp-block[data-align="full"] > .wp-block-group,
-.is-root-container .wp-block[data-align="full"] > .wp-block-cover {
+.is-root-container .alignfull > .wp-block-group,
+.is-root-container .alignfull > .wp-block-cover {
 	padding-left: var(--wp--custom--spacing--outer);
 	padding-right: var(--wp--custom--spacing--outer);
 }
@@ -309,7 +309,7 @@ body > .is-root-container,
 body > .is-root-container > .wp-block-cover,
 body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
 body > .is-root-container > .wp-block-template-part > .wp-block-cover,
-.is-root-container .wp-block[data-align="full"] {
+.is-root-container .alignfull {
 	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	width: unset;
@@ -317,13 +317,18 @@ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
 
 /* Blocks inside columns don't have negative margins. */
 .wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
-.is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
+.is-root-container .wp-block-columns .wp-block-column .wp-block.alignfull,
 /* We also want to avoid stacking negative margins. */
 .wp-site-blocks .alignfull:not(.wp-block-group) .alignfull,
-.is-root-container .wp-block[data-align="full"] > *:not(.wp-block-group) .wp-block[data-align="full"] {
+.is-root-container .wp-block.alignfull > *:not(.wp-block-group) .wp-block.alignfull {
 	margin-left: auto !important;
 	margin-right: auto !important;
 	width: inherit;
+}
+
+.block-editor-block-list__layout.is-root-container>.alignfull {
+	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
+	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 }
 
 .alignfull+.alignfull {


### PR DESCRIPTION
This PR is a stab at resolving an issue within the editor where fullscreen blocks were not displaying as such — but on the front-end they were. 