### PR TITLE
WooCommerce templates integration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -32,7 +32,7 @@ if ( ! function_exists( 'extendable_support' ) ) :
 		add_theme_support(
 			'woocommerce',
 			array(
-				'thumbnail_image_width' => 450,
+				'thumbnail_image_width' => 400,
 				'single_image_width'    => 600,
 			)
 		);

--- a/functions.php
+++ b/functions.php
@@ -25,6 +25,18 @@ if ( ! function_exists( 'extendable_support' ) ) :
 		// Enqueue editor styles.
 		add_editor_style( 'style.css' );
 
+		// Register WooCommerce theme features.
+		add_theme_support( 'wc-product-gallery-zoom' );
+		add_theme_support( 'wc-product-gallery-lightbox' );
+		add_theme_support( 'wc-product-gallery-slider' );
+		add_theme_support(
+			'woocommerce',
+			array(
+				'thumbnail_image_width' => 450,
+				'single_image_width'    => 600,
+			)
+		);
+
 	}
 
 endif;

--- a/templates/archive-product.html
+++ b/templates/archive-product.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+
+	<!-- wp:woocommerce/legacy-template {"template":"archive-product","align":"wide"} /-->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/page-cart.html
+++ b/templates/page-cart.html
@@ -1,0 +1,56 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","align":"full","layout":{"inherit":true}} -->
+<main class="wp-block-group alignfull">
+
+	<!-- wp:woocommerce/cart {"align":"wide"} -->
+	<div class="wp-block-woocommerce-cart alignwide is-loading"><!-- wp:woocommerce/filled-cart-block -->
+	<div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block -->
+	<div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block -->
+	<div class="wp-block-woocommerce-cart-line-items-block"></div>
+	<!-- /wp:woocommerce/cart-line-items-block --></div>
+	<!-- /wp:woocommerce/cart-items-block -->
+
+	<!-- wp:woocommerce/cart-totals-block -->
+	<div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block -->
+	<div class="wp-block-woocommerce-cart-order-summary-block"></div>
+	<!-- /wp:woocommerce/cart-order-summary-block -->
+
+	<!-- wp:woocommerce/cart-express-payment-block -->
+	<div class="wp-block-woocommerce-cart-express-payment-block"></div>
+	<!-- /wp:woocommerce/cart-express-payment-block -->
+
+	<!-- wp:woocommerce/proceed-to-checkout-block -->
+	<div class="wp-block-woocommerce-proceed-to-checkout-block"></div>
+	<!-- /wp:woocommerce/proceed-to-checkout-block -->
+
+	<!-- wp:woocommerce/cart-accepted-payment-methods-block -->
+	<div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div>
+	<!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div>
+	<!-- /wp:woocommerce/cart-totals-block --></div>
+	<!-- /wp:woocommerce/filled-cart-block -->
+
+	<!-- wp:woocommerce/empty-cart-block -->
+	<div class="wp-block-woocommerce-empty-cart-block">
+	<!-- wp:heading {"textAlign":"center","className":"wc-block-cart__empty-cart__title"} -->
+	<h2 class="has-text-align-center wc-block-cart__empty-cart__title">Your cart is currently empty!</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center"><a href="/shop/">Browse store</a>.</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:separator {"className":"is-style-dots"} -->
+	<hr class="wp-block-separator is-style-dots"/>
+	<!-- /wp:separator -->
+
+	<!-- wp:heading {"textAlign":"center"} -->
+	<h2 class="has-text-align-center">New in store</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/product-new {"rows":1} /--></div>
+	<!-- /wp:woocommerce/empty-cart-block --></div>
+	<!-- /wp:woocommerce/cart --></main>
+	<!-- /wp:group -->
+
+	<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/page-checkout.html
+++ b/templates/page-checkout.html
@@ -1,0 +1,51 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","align":"full","layout":{"inherit":true}} -->
+<main class="wp-block-group alignfull"><!-- wp:woocommerce/checkout {"align":"wide"} -->
+	<div class="wp-block-woocommerce-checkout alignwide wc-block-checkout is-loading"><!-- wp:woocommerce/checkout-fields-block -->
+	<div class="wp-block-woocommerce-checkout-fields-block"><!-- wp:woocommerce/checkout-express-payment-block -->
+	<div class="wp-block-woocommerce-checkout-express-payment-block"></div>
+	<!-- /wp:woocommerce/checkout-express-payment-block -->
+
+	<!-- wp:woocommerce/checkout-contact-information-block -->
+	<div class="wp-block-woocommerce-checkout-contact-information-block"></div>
+	<!-- /wp:woocommerce/checkout-contact-information-block -->
+
+	<!-- wp:woocommerce/checkout-shipping-address-block -->
+	<div class="wp-block-woocommerce-checkout-shipping-address-block"></div>
+	<!-- /wp:woocommerce/checkout-shipping-address-block -->
+
+	<!-- wp:woocommerce/checkout-billing-address-block -->
+	<div class="wp-block-woocommerce-checkout-billing-address-block"></div>
+	<!-- /wp:woocommerce/checkout-billing-address-block -->
+
+	<!-- wp:woocommerce/checkout-shipping-methods-block -->
+	<div class="wp-block-woocommerce-checkout-shipping-methods-block"></div>
+	<!-- /wp:woocommerce/checkout-shipping-methods-block -->
+
+	<!-- wp:woocommerce/checkout-payment-block -->
+	<div class="wp-block-woocommerce-checkout-payment-block"></div>
+	<!-- /wp:woocommerce/checkout-payment-block -->
+
+	<!-- wp:woocommerce/checkout-order-note-block -->
+	<div class="wp-block-woocommerce-checkout-order-note-block"></div>
+	<!-- /wp:woocommerce/checkout-order-note-block -->
+
+	<!-- wp:woocommerce/checkout-terms-block -->
+	<div class="wp-block-woocommerce-checkout-terms-block"></div>
+	<!-- /wp:woocommerce/checkout-terms-block -->
+
+	<!-- wp:woocommerce/checkout-actions-block -->
+	<div class="wp-block-woocommerce-checkout-actions-block"></div>
+	<!-- /wp:woocommerce/checkout-actions-block --></div>
+	<!-- /wp:woocommerce/checkout-fields-block -->
+
+	<!-- wp:woocommerce/checkout-totals-block -->
+	<div class="wp-block-woocommerce-checkout-totals-block"><!-- wp:woocommerce/checkout-order-summary-block -->
+	<div class="wp-block-woocommerce-checkout-order-summary-block"></div>
+	<!-- /wp:woocommerce/checkout-order-summary-block --></div>
+	<!-- /wp:woocommerce/checkout-totals-block --></div>
+	<!-- /wp:woocommerce/checkout --></main>
+	<!-- /wp:group -->
+
+	<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/product-search-results.html
+++ b/templates/product-search-results.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+
+	<!-- wp:woocommerce/legacy-template {"template":"archive-product","align":"wide"} /-->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/single-product.html
+++ b/templates/single-product.html
@@ -1,0 +1,9 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+	<!-- wp:woocommerce/legacy-template {"template":"single-product","align":"wide"} /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/taxonomy-product_cat.html
+++ b/templates/taxonomy-product_cat.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+
+	<!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_cat","align":"wide"} /-->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/taxonomy-product_tag.html
+++ b/templates/taxonomy-product_tag.html
@@ -1,0 +1,11 @@
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+
+	<!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_tag","align":"wide"} /-->
+
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
This introduces a good baseline coverage of templates for WooCommerce support.

No custom CSS has been needed and only adding in templates for now. Further CSS enhancements will continue to be explored in #60 , but I think these templates will offer value to end users.

Screenshots with Hong Kong style variation:

![extendable local_shop_](https://user-images.githubusercontent.com/405912/173422068-e56e26c5-6545-4ad9-a139-45d554d75c4b.png)

![extendable local_product_beanie_](https://user-images.githubusercontent.com/405912/173422111-5e313f9e-24db-4e6f-a321-e4261d5d946a.png)

![extendable local_cart_](https://user-images.githubusercontent.com/405912/173422142-459e3505-ffdc-4826-851e-ba3ad19e1322.png)

![extendable local_checkout_](https://user-images.githubusercontent.com/405912/173422172-91db1764-89d5-4042-9477-acc18a227f99.png)

![extendable local_my-account_](https://user-images.githubusercontent.com/405912/173422201-112fd4b2-f449-4433-8744-4247ab2a238a.png)

