### PR TITLE
Streamline style variations

### DIFF
--- a/styles/brisbane.json
+++ b/styles/brisbane.json
@@ -1,59 +1,9 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
-	"title": "Brisbane",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
+	"title": "Brisbane",
 	"settings": {
-		"appearanceTools": true,
 		"color": {
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
-				}
-			],
 			"palette": [
 				{
 					"slug": "foreground",
@@ -101,9 +51,7 @@
 							"bottomRight": "7px",
 							"topLeft": "12px",
 							"topRight": "16px"
-						},
-						"style": "solid solid solid solid",
-						"width": "1px !important"
+						}
 					},
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
@@ -118,47 +66,11 @@
 						}
 					},
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--heading)",
+						"fontFamily": "var(--wp--preset--font-family--headings)",
 						"fontSize": "var(--wp--custom--typography--font-size--large)",
 						"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-						"letterSpacing": "0.03em",
-						"lineHeight": "1",
-						"textTransform": "none"
+						"letterSpacing": "0.03em"
 					}
-				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
-			},
-			"typography": {
-				"fontSmoothing": {
-					"moz": "grayscale",
-					"webkit": "antialiased"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "350",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.15,
-					"small": 1.3,
-					"medium": 1.5,
-					"normal": 1.6
 				}
 			}
 		},
@@ -167,12 +79,11 @@
 			"wideSize": "68rem"
 		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Arsenal\", serif",
-					"name": "Headings (System Font)",
-					"slug": "heading",
+					"name": "Headings (Arsenal)",
+					"slug": "headings",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
@@ -194,7 +105,7 @@
 				},
 				{
 					"fontFamily": "\"Radio Canada\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Radio Canada)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -209,111 +120,14 @@
 						}
 					]
 				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
-				}
 			]
 		}
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0"
+					"fontSize": "var(--wp--preset--font-size--x-large)"
 				}
 			},
 			"core/group": {
@@ -336,87 +150,22 @@
 					}
 				}
 			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.01em"
 				}
 			},
 			"core/pullquote": {
 				"border": {
-					"color": "transparent",
 					"radius": {
 						"bottomLeft": "18%",
 						"bottomRight": "15%",
 						"topLeft": "10%",
 						"topRight": "23%"
 					},
-					"style": "solid",
 					"width": "1px"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
 				}
 			},
 			"core/query-pagination-next": {
@@ -436,7 +185,6 @@
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
@@ -445,92 +193,49 @@
 			"core/quote": {
 				"border": {
 					"color": "var(--wp--preset--color--secondary)",
-					"style": "solid",
 					"width": "0 0 0 15px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.02em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "-0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "-0.01em"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.01em"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.02em"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"letterSpacing": "0.04em"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0.04em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--bold)"
 				}
 			}
 		},
@@ -538,22 +243,7 @@
 			"blockGap": "min(30px, 5vw)"
 		},
 		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--medium)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
+			"lineHeight": "var(--wp--custom--typography--line-height--medium)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/cairo.json
+++ b/styles/cairo.json
@@ -2,15 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"title": "Cairo",
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
@@ -32,48 +24,6 @@
 					"colors": ["#002522", "#98d3d0"],
 					"slug": "primary-and-secondary",
 					"name": "Primary and secondary"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -105,26 +55,10 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
 						"color": "var(--wp--preset--color--primary)",
-						"radius": {
-							"bottomLeft": "100rem",
-							"bottomRight": "100rem",
-							"topLeft": "100rem",
-							"topRight": "100rem"
-						},
-						"style": "solid solid solid solid",
 						"width": "2px !important"
 					},
 					"color": {
@@ -138,61 +72,15 @@
 							"right": "2rem",
 							"left": "2rem"
 						}
-					},
-					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--body)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
-						"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-						"letterSpacing": "0",
-						"lineHeight": "1",
-						"textTransform": "none"
 					}
-				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
-			},
-			"typography": {
-				"fontSmoothing": {
-					"moz": "auto",
-					"webkit": "auto"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "400",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.15,
-					"small": 1.2,
-					"medium": 1.4,
-					"normal": 1.6
 				}
 			}
 		},
-		"spacing": {
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
-		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Source Serif 4\", serif",
-					"name": "Body (System Font)",
+					"name": "Body (Source Serif 4)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -209,48 +97,8 @@
 				},
 				{
 					"fontFamily": "\"Source Serif 4\", serif",
-					"name": "Headings (System Font)",
-					"slug": "heading"
-				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
+					"name": "Headings (Source Serif 4)",
+					"slug": "headings"
 				}
 			]
 		},
@@ -261,169 +109,21 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
+					"fontSize": "var(--wp--preset--font-size--x-large)"
 				}
 			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
 					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid",
 					"width": "2px 0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
 				}
 			},
 			"core/query-pagination-next": {
@@ -443,122 +143,52 @@
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
 					"width": "0 0 0 2px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "clamp(1.2rem, 3vw, 1.5rem)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
 					"letterSpacing": "-.025em"
 				}
 			}
 		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
-		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
-				}
-			},
-			"h5": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
+					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0.04em",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			}
-		},
-		"spacing": {
-			"blockGap": "2rem"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/gdansk.json
+++ b/styles/gdansk.json
@@ -2,15 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Gdansk",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
@@ -32,48 +24,6 @@
 					"colors": ["#0c0c0b", "#083021"],
 					"slug": "background-and-tertiary",
 					"name": "Background and tertiary"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -105,15 +55,6 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
@@ -124,12 +65,10 @@
 							"topLeft": "999px",
 							"topRight": "999px"
 						},
-						"style": "solid solid solid solid",
 						"width": "4px !important"
 					},
 					"color": {
-						"background": "var(--wp--preset--color--primary)",
-						"text": "var(--wp--preset--color--background)"
+						"background": "var(--wp--preset--color--primary)"
 					},
 					"spacing": {
 						"padding": {
@@ -140,46 +79,11 @@
 						}
 					},
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--heading)",
+						"fontFamily": "var(--wp--preset--font-family--headings)",
 						"fontSize": "var(--wp--preset--font-size--small)",
 						"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-						"letterSpacing": "0.03em",
-						"lineHeight": "1",
-						"textTransform": "none"
+						"letterSpacing": "0.03em"
 					}
-				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
-			},
-			"typography": {
-				"fontSmoothing": {
-					"moz": "grayscale",
-					"webkit": "antialiased"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "400",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.1,
-					"small": 1.25,
-					"medium": 1.4
 				}
 			}
 		},
@@ -188,11 +92,10 @@
 			"wideSize": "68rem"
 		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Inter\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Inter)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -209,8 +112,8 @@
 				},
 				{
 					"fontFamily": "\"Montserrat\", sans-serif",
-					"name": "Headings (System Font)",
-					"slug": "heading",
+					"name": "Headings (Montserrat)",
+					"slug": "headings",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
@@ -224,214 +127,29 @@
 						}
 					]
 				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
-				}
 			]
 		}
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
 					"fontSize": "var(--wp--custom--typography--font-size--huge)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
 					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid",
 					"width": "7px 0"
 				},
 				"color": {
-					"background": "transparent",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
+					"background": "transparent"
 				}
 			},
 			"core/query-pagination-next": {
@@ -451,123 +169,52 @@
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
 					"width": "0 0 0 5px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0.03em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.03em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--thin)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"letterSpacing": "0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
-				}
-			},
-			"h5": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"letterSpacing": "0.01em",
-					"textTransform": "normal"
+					"letterSpacing": "0.01em"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"letterSpacing": "0.02em"
 				}
 			}
 		},
 		"spacing": {
 			"blockGap": "min(40px, 9vw)"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--medium)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/glasgow.json
+++ b/styles/glasgow.json
@@ -2,63 +2,13 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Glasgow",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
 					"colors": ["#f24139", "#ffdda6"],
 					"slug": "foreground-and-background",
 					"name": "Foreground and background"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -90,15 +40,6 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
@@ -109,7 +50,6 @@
 							"topLeft": "8px",
 							"topRight": "8px"
 						},
-						"style": "solid solid solid solid",
 						"width": "2px !important"
 					},
 					"color": {
@@ -123,61 +63,15 @@
 							"right": "clamp(1.5rem, 2.5vw, 2rem)",
 							"left": "clamp(1.5rem, 2.5vw, 2rem)"
 						}
-					},
-					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--body)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
-						"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-						"letterSpacing": "0",
-						"lineHeight": "1",
-						"textTransform": "none"
 					}
-				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
-			},
-			"typography": {
-				"fontSmoothing": {
-					"moz": "grayscale",
-					"webkit": "antialiased"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "400",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.15,
-					"small": 1.2,
-					"medium": 1.4,
-					"normal": 1.6
 				}
 			}
 		},
-		"spacing": {
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
-		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Rubik\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Rubik)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -192,48 +86,8 @@
 				},
 				{
 					"fontFamily": "\"Rubik\", sans-serif",
-					"name": "Headings (System Font)",
-					"slug": "heading"
-				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
+					"name": "Headings (Rubik)",
+					"slug": "headings"
 				}
 			]
 		},
@@ -244,304 +98,77 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
+					"fontWeight": "(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
 					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid",
 					"width": "2px 0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-numbers": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
 					"width": "0 0 0 2px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "clamp(1.2rem, 3vw, 1.5rem)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "-.025em",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)"
+					"letterSpacing": "-.025em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--extra-bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--extra-bold)"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--black)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
+					"fontWeight": "var(--wp--custom--typography--font-weight--black)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--extra-bold)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"letterSpacing": "0.02em"
 				}
 			}
-		},
-		"spacing": {
-			"blockGap": "2rem"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-			"lineHeight": "var(--wp--custom--typography--line-height--normal)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/hong-kong.json
+++ b/styles/hong-kong.json
@@ -2,15 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Hong Kong",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
@@ -27,48 +19,6 @@
 					"colors": ["#dc1912", "#edc7c7"],
 					"slug": "primary-and-secondary",
 					"name": "Primary and secondary"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -100,27 +50,10 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
-						"color": "var(--wp--preset--color--primary)",
-						"radius": {
-							"bottomLeft": "100rem",
-							"bottomRight": "100rem",
-							"topLeft": "100rem",
-							"topRight": "100rem"
-						},
-						"style": "solid solid solid solid",
-						"width": "1px !important"
+						"color": "var(--wp--preset--color--primary)"
 					},
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
@@ -133,50 +66,15 @@
 							"right": "2rem",
 							"left": "2rem"
 						}
-					},
-					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--body)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
-						"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-						"letterSpacing": "0",
-						"lineHeight": "1",
-						"textTransform": "none"
 					}
-				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
-			},
-			"typography": {
-				"fontSmoothing": {
-					"moz": "grayscale",
-					"webkit": "antialiased"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"line-height": {
-					"tiny": 1.2,
-					"small": 1.3,
-					"medium": 1.5,
-					"normal": 1.7
 				}
 			}
 		},
-		"spacing": {
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
-		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Space Mono\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
-					"name": "Body (System Font)",
+					"name": "Body (Space Mono)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -195,48 +93,8 @@
 				},
 				{
 					"fontFamily": "\"Space Mono\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
-					"name": "Headings (System Font)",
-					"slug": "heading"
-				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
+					"name": "Headings (Space Mono)",
+					"slug": "headings"
 				}
 			]
 		},
@@ -247,169 +105,21 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
+					"fontWeight": "(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid",
-					"width": "1px 0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
+					"color": "var(--wp--preset--color--primary)"
 				}
 			},
 			"core/query-pagination-next": {
@@ -429,121 +139,43 @@
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--space-mono)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
-				}
-			},
-			"core/quote": {
-				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
-					"width": "0 0 0 1px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
-				}
-			},
-			"core/site-title": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--inter)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"textTransform": "uppercase"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			}
-		},
-		"spacing": {
-			"blockGap": "2rem"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-			"lineHeight": "var(--wp--custom--typography--line-height--normal)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/kampala.json
+++ b/styles/kampala.json
@@ -2,58 +2,8 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Kampala",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
-				}
-			],
 			"palette": [
 				{
 					"slug": "foreground",
@@ -83,15 +33,6 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
@@ -102,7 +43,6 @@
 							"topLeft": "4px",
 							"topRight": "4px"
 						},
-						"style": "solid solid solid solid",
 						"width": "2px !important"
 					},
 					"color": {
@@ -118,59 +58,16 @@
 						}
 					},
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--body)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
-						"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-						"letterSpacing": "0.03em",
-						"lineHeight": "1",
-						"textTransform": "none"
+						"letterSpacing": "0.03em"
 					}
-				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
-			},
-			"typography": {
-				"fontSmoothing": {
-					"moz": "grayscale",
-					"webkit": "antialiased"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "400",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.15,
-					"small": 1.2,
-					"medium": 1.4,
-					"normal": 1.6
 				}
 			}
 		},
-		"spacing": {
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
-		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Hind\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Hind)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -185,48 +82,8 @@
 				},
 				{
 					"fontFamily": "\"Hind\", sans-serif",
-					"name": "Headings (System Font)",
-					"slug": "heading"
-				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
+					"name": "Headings (Hind)",
+					"slug": "headings"
 				}
 			]
 		},
@@ -237,205 +94,24 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comments-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--black)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--black)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
-					"color": "transparent",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid",
 					"width": "2px 0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-numbers": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--black)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--black)"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
 					"width": "0 0 0 2px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
 				}
 			},
 			"core/separator": {
@@ -445,97 +121,25 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.02em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "-0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
-				}
-			},
-			"h2": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
-				}
-			},
-			"h3": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
-				}
-			},
-			"h4": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
-				}
-			},
-			"h5": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
+					"letterSpacing": "-0.01em"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0.03em",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--primary)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--bold)"
 				}
 			}
 		},
 		"spacing": {
 			"blockGap": "2.2rem"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/odesa.json
+++ b/styles/odesa.json
@@ -2,15 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Odesa",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
@@ -32,48 +24,6 @@
 					"colors": ["#063483", "#F8D648"],
 					"slug": "primary-and-secondary",
 					"name": "Primary and secondary"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -105,15 +55,6 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
@@ -123,9 +64,7 @@
 							"bottomRight": "4px",
 							"topLeft": "4px",
 							"topRight": "4px"
-						},
-						"style": "solid solid solid solid",
-						"width": "1px !important"
+						}
 					},
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
@@ -140,46 +79,11 @@
 						}
 					},
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--heading)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
+						"fontFamily": "var(--wp--preset--font-family--headings)",
 						"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
 						"letterSpacing": "0.03em",
-						"lineHeight": "1",
 						"textTransform": "uppercase"
 					}
-				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
-			},
-			"typography": {
-				"fontSmoothing": {
-					"moz": "grayscale",
-					"webkit": "antialiased"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "400",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.1,
-					"small": 1.25,
-					"medium": 1.4
 				}
 			}
 		},
@@ -188,11 +92,10 @@
 			"wideSize": "77rem"
 		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Inter\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Inter)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -209,8 +112,8 @@
 				},
 				{
 					"fontFamily": "\"Roboto Flex\", sans-serif",
-					"name": "Headings (System Font)",
-					"slug": "heading",
+					"name": "Headings (Roboto Flex)",
+					"slug": "headings",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
@@ -224,214 +127,27 @@
 						}
 					]
 				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
-				}
 			]
 		}
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
 					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
 					"style": "double none double none",
 					"width": "7px"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
 				}
 			},
 			"core/query-pagination-next": {
@@ -451,23 +167,14 @@
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--black)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--black)"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
 					"style": "none none none double",
 					"width": "0 0 0 5px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
 				}
 			},
 			"core/separator": {
@@ -477,99 +184,50 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.02em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)",
-					"letterSpacing": "-0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "-0.01em"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.01em"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"letterSpacing": "0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
 					"textTransform": "normal"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--black)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"letterSpacing": "0.02em"
 				}
 			}
 		},
 		"spacing": {
 			"blockGap": "min(32px, 7vw)"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--medium)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/piraeus.json
+++ b/styles/piraeus.json
@@ -2,15 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Piraeus",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
@@ -32,48 +24,6 @@
 					"colors": ["#0d0c0c", "#f0ede6"],
 					"slug": "primary-and-secondary",
 					"name": "Primary and secondary"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -105,15 +55,6 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
@@ -124,7 +65,6 @@
 							"topLeft": "0px",
 							"topRight": "0px"
 						},
-						"style": "solid solid solid solid",
 						"width": "2px !important"
 					},
 					"color": {
@@ -140,47 +80,17 @@
 						}
 					},
 					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--heading)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
+						"fontFamily": "var(--wp--preset--font-family--headings)",
 						"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
 						"letterSpacing": "0.02em",
-						"lineHeight": "1",
 						"textTransform": "uppercase"
 					}
 				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
 			},
 			"typography": {
 				"fontSmoothing": {
 					"moz": "auto",
 					"webkit": "auto"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "400",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.1,
-					"small": 1.3,
-					"medium": 1.5,
-					"normal": 1.6
 				}
 			}
 		},
@@ -189,11 +99,10 @@
 			"wideSize": "78rem"
 		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Roboto Flex\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Roboto Flex)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -210,8 +119,8 @@
 				},
 				{
 					"fontFamily": "\"Geom\", sans-serif",
-					"name": "Headings (System Font)",
-					"slug": "heading",
+					"name": "Headings (Geom)",
+					"slug": "headings",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
@@ -223,310 +132,71 @@
 						}
 					]
 				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
-				}
 			]
 		}
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
+					"fontWeight": "(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
 					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid solid solid solid",
 					"width": "6px 0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-numbers": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontSize": "var(--wp--preset--font-size--xx-large)"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
 					"width": "0 0 0 6px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"letterSpacing": "0.03em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.03em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"letterSpacing": "-0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "-0.02em"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--light)",
-					"letterSpacing": "0.04em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.04em"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
 					"letterSpacing": "0.01em",
 					"textTransform": "normal"
@@ -534,39 +204,12 @@
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0.03em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			}
 		},
 		"spacing": {
 			"blockGap": "min(48px, 6vw)"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--medium)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/porto.json
+++ b/styles/porto.json
@@ -2,58 +2,8 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Porto",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
-				}
-			],
 			"palette": [
 				{
 					"slug": "foreground",
@@ -83,19 +33,9 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"block": {
 					"border": {
-						"color": "currentColor",
 						"radius": {
 							"bottomLeft": "0px",
 							"bottomRight": "0px",
@@ -116,61 +56,15 @@
 							"right": "1.6rem",
 							"left": "1.6rem"
 						}
-					},
-					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--body)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
-						"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-						"letterSpacing": "0",
-						"lineHeight": "1",
-						"textTransform": "none"
 					}
-				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
-			},
-			"typography": {
-				"fontSmoothing": {
-					"moz": "grayscale",
-					"webkit": "antialiased"
-				},
-				"font-size": {
-					"huge": "clamp(3rem, 2.545rem + 2.27vw, 4.25rem)",
-					"gigantic": "clamp(3.875rem, 3.33rem + 2.73vw, 5.375rem)",
-					"colossal": "clamp(4.875rem, 4.375rem + 2.5vw, 6.25rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "400",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.15,
-					"small": 1.2,
-					"medium": 1.4,
-					"normal": 1.6
 				}
 			}
 		},
-		"spacing": {
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
-		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Inconsolata\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Inconsolata)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -187,8 +81,8 @@
 				},
 				{
 					"fontFamily": "\"Karla\", sans-serif",
-					"name": "Headings (System Font)",
-					"slug": "heading",
+					"name": "Headings (Karla)",
+					"slug": "headings",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
@@ -200,46 +94,6 @@
 						}
 					]
 				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(2.375rem, 2.148rem + 1.14vw, 3rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
-				}
 			]
 		},
 		"layout": {
@@ -249,307 +103,72 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
+					"fontSize": "var(--wp--preset--font-size--x-large)"
 				}
 			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
 					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid solid solid solid",
 					"width": "2px 0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-numbers": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"fontSize": "var(--wp--preset--font-size--x-large)"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
 					"width": "0 0 0 2px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.02em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)",
-					"letterSpacing": "-0.07em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "-0.07em"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "-0.04em",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"letterSpacing": "-0.04em"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "-0.03em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "-0.03em"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "-0.03em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "-0.03em"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
+					"fontWeight": "var(--wp--custom--typography--font-weight--bold)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--extra-bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--extra-bold)"
 				}
 			}
-		},
-		"spacing": {
-			"blockGap": "2rem"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/rio.json
+++ b/styles/rio.json
@@ -2,15 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Rio",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
@@ -32,48 +24,6 @@
 					"colors": ["#ffd800", "#7cb5e3"],
 					"slug": "primary-and-tertiary",
 					"name": "Primary and tertiary"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -105,94 +55,29 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
-						"color": "var(--wp--preset--color--primary)",
-						"radius": {
-							"bottomLeft": "100rem",
-							"bottomRight": "100rem",
-							"topLeft": "100rem",
-							"topRight": "100rem"
-						},
-						"style": "solid solid solid solid",
-						"width": "1px !important"
+						"color": "var(--wp--preset--color--primary)"
 					},
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
 						"text": "var(--wp--preset--color--foreground)"
-					},
-					"spacing": {
-						"padding": {
-							"top": "clamp(1.1rem, 1.5vw, 1.5rem)",
-							"bottom": "clamp(1.1rem, 1.5vw, 1.5rem)",
-							"right": "clamp(1.25rem, 2.5vw, 2rem)",
-							"left": "clamp(1.25rem, 2.5vw, 2rem)"
-						}
-					},
-					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--body)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
-						"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-						"letterSpacing": "0",
-						"lineHeight": "1",
-						"textTransform": "none"
 					}
 				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
 			},
 			"typography": {
 				"fontSmoothing": {
 					"moz": "auto",
 					"webkit": "auto"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "400",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.2,
-					"small": 1.3,
-					"medium": 1.5,
-					"normal": 1.7
 				}
 			}
 		},
-		"spacing": {
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
-		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Space Mono\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
-					"name": "Body (System Font)",
+					"name": "Body (Space Mono)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -211,48 +96,8 @@
 				},
 				{
 					"fontFamily": "\"Space Mono\", Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
-					"name": "Headings (System Font)",
-					"slug": "heading"
-				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
+					"name": "Headings (Space Mono)",
+					"slug": "headings"
 				}
 			]
 		},
@@ -263,303 +108,73 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
+					"fontWeight": "(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid",
-					"width": "1px 0"
+					"color": "var(--wp--preset--color--primary)"
 				},
 				"color": {
-					"background": "transparent",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-numbers": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
+					"background": "transparent"
 				}
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
-				}
-			},
-			"core/quote": {
-				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
-					"width": "0 0 0 1px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"letterSpacing": "-0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "-0.02em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"textTransform": "uppercase"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			}
 		},
 		"spacing": {
 			"blockGap": "min(50px, 8vw)"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-			"lineHeight": "var(--wp--custom--typography--line-height--normal)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/santa-fe.json
+++ b/styles/santa-fe.json
@@ -2,15 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Santa Fe",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
@@ -32,48 +24,6 @@
 					"colors": ["#1f033b", "#f0ede4"],
 					"slug": "primary-and-tertiary",
 					"name": "Primary and tertiary"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -105,31 +55,13 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
-						"color": "var(--wp--preset--color--primary)",
-						"radius": {
-							"bottomLeft": "100rem",
-							"bottomRight": "100rem",
-							"topLeft": "100rem",
-							"topRight": "100rem"
-						},
-						"style": "solid solid solid solid",
-						"width": "1px !important"
+						"color": "var(--wp--preset--color--primary)"
 					},
 					"color": {
-						"background": "var(--wp--preset--color--primary)",
-						"text": "var(--wp--preset--color--background)"
+						"background": "var(--wp--preset--color--primary)"
 					},
 					"spacing": {
 						"padding": {
@@ -138,49 +70,13 @@
 							"right": "clamp(1.18rem, 2.5vw, 2rem)",
 							"left": "clamp(1.18rem, 2.5vw, 2rem)"
 						}
-					},
-					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--body)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
-						"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-						"letterSpacing": "0",
-						"lineHeight": "1",
-						"textTransform": "none"
 					}
 				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
 			},
 			"typography": {
 				"fontSmoothing": {
 					"moz": "auto",
 					"webkit": "auto"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "400",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.15,
-					"small": 1.3,
-					"medium": 1.5,
-					"normal": 1.6
 				}
 			}
 		},
@@ -189,11 +85,10 @@
 			"wideSize": "70rem"
 		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Radio Canada\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Radio Canada)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -210,8 +105,8 @@
 				},
 				{
 					"fontFamily": "\"Noto Serif Display\", serif",
-					"name": "Headings (System Font)",
-					"slug": "heading",
+					"name": "Headings (Noto Serif Display)",
+					"slug": "headings",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
@@ -225,349 +120,72 @@
 						}
 					]
 				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
-				}
 			]
 		}
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comments-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "(--wp--custom--typography--font-weight--semi-bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
 					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid solid solid solid",
 					"width": "2px 0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-numbers": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--bold)"
 				}
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
 					"width": "0 0 0 2px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"letterSpacing": "-0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "-0.02em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"letterSpacing": "-0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "-0.01em"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
-				}
-			},
-			"h5": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"letterSpacing": "0.03em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--bold)"
 				}
 			}
 		},
 		"spacing": {
 			"blockGap": "min(28px, 6vw)"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--medium)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--light)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/thimphu.json
+++ b/styles/thimphu.json
@@ -2,15 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Thimphu",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
@@ -32,48 +24,6 @@
 					"colors": ["#ffebcc", "#3a312e"],
 					"slug": "background-and-primary",
 					"name": "Background and primary"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -105,15 +55,6 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
@@ -123,9 +64,7 @@
 							"bottomRight": "0",
 							"topLeft": "0",
 							"topRight": "0"
-						},
-						"style": "solid solid solid solid",
-						"width": "1px !important"
+						}
 					},
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
@@ -138,61 +77,21 @@
 							"right": "2rem",
 							"left": "2rem"
 						}
-					},
-					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--body)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
-						"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-						"letterSpacing": "0.02em",
-						"lineHeight": "1",
-						"textTransform": "none"
 					}
 				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
 			},
 			"typography": {
 				"fontSmoothing": {
 					"moz": "auto",
 					"webkit": "auto"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "350",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.15,
-					"small": 1.2,
-					"medium": 1.4,
-					"normal": 1.6
 				}
 			}
 		},
-		"spacing": {
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
-		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Heebo\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Heebo)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -207,48 +106,8 @@
 				},
 				{
 					"fontFamily": "\"Heebo\", sans-serif",
-					"name": "Headings (System Font)",
-					"slug": "heading"
-				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
+					"name": "Headings (Heebo)",
+					"slug": "headings"
 				}
 			]
 		},
@@ -259,303 +118,67 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--extra-semi-bold)",
-					"letterSpacing": "0"
-				}
-			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
+					"fontWeight": "var(--wp--custom--typography--font-weight--extra-semi-bold)"
 				}
 			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)",
-					"letterSpacing": "0",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)"
 				}
 			},
 			"core/pullquote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid solid solid solid",
-					"width": "1px 0"
+					"color": "var(--wp--preset--color--primary)"
 				},
 				"color": {
-					"background": "transparent",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-numbers": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
+					"background": "transparent"
 				}
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
-				}
-			},
-			"core/quote": {
-				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
-					"width": "0 0 0 1px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
-				}
-			},
-			"core/site-title": {
-				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"letterSpacing": "-.025em"
+					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--thin)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--extra-light)"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heebo)",
-					"fontSize": "var(--wp--preset--font-size--large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--black)",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--black)"
 				}
 			}
 		},
 		"spacing": {
 			"blockGap": "min(50px, 9vw)"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-			"lineHeight": "var(--wp--custom--typography--line-height--normal)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/styles/tokyo.json
+++ b/styles/tokyo.json
@@ -2,15 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Tokyo",
 	"version": 2,
-	"customTemplates": [
-		{
-			"name": "blank",
-			"title": "Blank",
-			"postTypes": ["page", "post"]
-		}
-	],
 	"settings": {
-		"appearanceTools": true,
 		"color": {
 			"duotone": [
 				{
@@ -32,48 +24,6 @@
 					"colors": ["#010101", "#ffffff"],
 					"slug": "foreground-and-background",
 					"name": "Foreground and background"
-				}
-			],
-			"gradients": [
-				{
-					"slug": "vertical-secondary-to-tertiary",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--tertiary) 100%)",
-					"name": "Vertical secondary to tertiary"
-				},
-				{
-					"slug": "vertical-secondary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--secondary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical secondary to background"
-				},
-				{
-					"slug": "vertical-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom,var(--wp--preset--color--tertiary) 0%,var(--wp--preset--color--background) 100%)",
-					"name": "Vertical tertiary to background"
-				},
-				{
-					"slug": "diagonal-primary-to-foreground",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--primary) 0%,var(--wp--preset--color--foreground) 100%)",
-					"name": "Diagonal primary to foreground"
-				},
-				{
-					"slug": "diagonal-secondary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--secondary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal secondary to background"
-				},
-				{
-					"slug": "diagonal-background-to-secondary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--secondary) 50%)",
-					"name": "Diagonal background to secondary"
-				},
-				{
-					"slug": "diagonal-tertiary-to-background",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--tertiary) 50%,var(--wp--preset--color--background) 50%)",
-					"name": "Diagonal tertiary to background"
-				},
-				{
-					"slug": "diagonal-background-to-tertiary",
-					"gradient": "linear-gradient(to bottom right,var(--wp--preset--color--background) 50%,var(--wp--preset--color--tertiary) 50%)",
-					"name": "Diagonal background to tertiary"
 				}
 			],
 			"palette": [
@@ -105,93 +55,35 @@
 			]
 		},
 		"custom": {
-			"blocks": {
-				"core/table": {
-					"variantStripes": {
-						"color": {
-							"background": "var(--wp--preset--color--tertiary)"
-						}
-					}
-				}
-			},
 			"elements": {
 				"button": {
 					"border": {
+						"color": "var(--wp--preset--color--primary)",
 						"radius": {
 							"bottomLeft": "5px",
 							"bottomRight": "5px",
 							"topLeft": "5px",
 							"topRight": "5px"
-						},
-						"style": "solid solid solid solid",
-						"width": "1px !important"
+						}
 					},
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
 						"text": "var(--wp--preset--color--secondary)"
-					},
-					"spacing": {
-						"padding": {
-							"top": "clamp(1.1rem, 1.5vw, 1.5rem)",
-							"bottom": "clamp(1.1rem, 1.5vw, 1.5rem)",
-							"right": "clamp(1.25rem, 2.5vw, 2rem)",
-							"left": "clamp(1.25rem, 2.5vw, 2rem)"
-						}
-					},
-					"typography": {
-						"fontFamily": "var(--wp--preset--font-family--body)",
-						"fontSize": "var(--wp--preset--font-size--medium)",
-						"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-						"letterSpacing": "0",
-						"lineHeight": "1",
-						"textTransform": "none"
 					}
 				}
-			},
-			"spacing": {
-				"small": "clamp(1rem, 0.818rem + 0.91vw, 1.5rem)",
-				"medium": "clamp(1.5rem, 1.318rem + 0.91vw, 2rem)",
-				"large": "clamp(2.5rem, 1.864rem + 3.18vw, 4.25rem)",
-				"outer": "var(--wp--custom--spacing--small, 1.25rem)"
 			},
 			"typography": {
 				"fontSmoothing": {
 					"moz": "auto",
 					"webkit": "auto"
-				},
-				"font-size": {
-					"huge": "clamp(2.25rem, 1.977rem + 1.36vw, 3rem)",
-					"gigantic": "clamp(3.125rem, 2.489rem + 3.18vw, 4.875rem)",
-					"colossal": "clamp(3.875rem, 3.239rem + 3.18vw, 5.625rem)"
-				},
-				"font-weight": {
-					"black": "900",
-					"extraBold": "800",
-					"bold": "700",
-					"semiBold": "600",
-					"medium": "500",
-					"regular": "350",
-					"light": "300",
-					"extraLight": "200",
-					"thin": "100"
-				},
-				"line-height": {
-					"tiny": 1.15,
-					"small": 1.2,
-					"medium": 1.4,
-					"normal": 1.6
 				}
 			}
 		},
-		"spacing": {
-			"units": ["%", "px", "em", "rem", "vh", "vw"]
-		},
 		"typography": {
-			"dropCap": false,
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Inter\", sans-serif",
-					"name": "Body (System Font)",
+					"name": "Body (Inter)",
 					"slug": "body",
 					"fontFace": [
 						{
@@ -208,8 +100,8 @@
 				},
 				{
 					"fontFamily": "\"Koulen\", sans-serif",
-					"name": "Headings (System Font)",
-					"slug": "heading",
+					"name": "Headings (Koulen)",
+					"slug": "headings",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
@@ -221,46 +113,6 @@
 						}
 					]
 				}
-			],
-			"fontSizes": [
-				{
-					"size": "clamp(0.94rem, 0.9rem + 0.2vw, 1.05rem)",
-					"slug": "small"
-				},
-				{
-					"size": "1.15rem",
-					"slug": "medium"
-				},
-				{
-					"name": "Large (H6)",
-					"size": "clamp(1.125rem, 1.08rem + 0.23vw, 1.25rem)",
-					"slug": "large"
-				},
-				{
-					"name": "X Large (H5)",
-					"size": "clamp(1.25rem, 1.068rem + 0.91vw, 1.75rem)",
-					"slug": "x-large"
-				},
-				{
-					"name": "2X Large (H4)",
-					"size": "clamp(1.75rem, 1.568rem + 0.91vw, 2.25rem)",
-					"slug": "xx-large"
-				},
-				{
-					"name": "Huge (H3)",
-					"size": "var(--wp--custom--typography--font-size--huge, 4.5rem)",
-					"slug": "huge"
-				},
-				{
-					"name": "Gigantic (H2)",
-					"size": "var(--wp--custom--typography--font-size--gigantic, 4.8rem)",
-					"slug": "gigantic"
-				},
-				{
-					"name": "Colossal (H1)",
-					"size": "var(--wp--custom--typography--font-size--colossal, 5.4rem)",
-					"slug": "colossal"
-				}
 			]
 		},
 		"layout": {
@@ -270,308 +122,76 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"border": {
-					"color": "var(--wp--custom--elements--button--border--color, currentColor)",
-					"radius": {
-						"bottomLeft": "var(--wp--custom--elements--button--border--radius--bottom-left, 0)",
-						"bottomRight": "var(--wp--custom--elements--button--border--radius--bottom-right, 0)",
-						"topLeft": "var(--wp--custom--elements--button--border--radius--top-left, 0)",
-						"topRight": "var(--wp--custom--elements--button--border--radius--top-right, 0)"
-					},
-					"style": "var(--wp--custom--elements--button--border--style, solid)",
-					"width": "var(--wp--custom--elements--button--border--width, 1px)"
-				},
-				"color": {
-					"background": "var(--wp--custom--elements--button--color--background, --wp--preset--color--primary)",
-					"text": "var(--wp--custom--elements--button--color--text, currentColor)"
-				},
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--elements--button--spacing--padding--top, 1.1rem)",
-						"bottom": "var(--wp--custom--elements--button--spacing--padding--bottom, 1.1rem)",
-						"right": "var(--wp--custom--elements--button--spacing--padding--right, 2rem)",
-						"left": "var(--wp--custom--elements--button--spacing--padding--left, 2rem)"
-					}
-				},
-				"typography": {
-					"fontFamily": "var(--wp--custom--elements--button--typography--font-family, inherit)",
-					"fontSize": "var(--wp--custom--elements--button--typography--font-size, inherit)",
-					"fontWeight": "var(--wp--custom--elements--button--typography--font-weight, 400)",
-					"letterSpacing": "var(--wp--custom--elements--button--typography--letter-spacing, 0)",
-					"lineHeight": "var(--wp--custom--elements--button--typography--line-height, 1)",
-					"textTransform": "var(--wp--custom--elements--button--typography--text-transform, none)"
-				}
-			},
-			"core/comment-content": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				}
-			},
-			"core/comment-edit-link": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/comment-reply-link": {
-				"spacing": {
-					"margin": {
-						"top": "0 !important"
-					}
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"core/comments-title": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
 					"letterSpacing": "0.03em"
 				}
 			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/navigation": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-comments": {
-				"spacing": {
-					"padding": {
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				}
-			},
-			"core/post-content": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/post-date": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
-			"core/post-excerpt": {
-				"spacing": {
-					"margin": {
-						"top": "calc(-1 * var(--wp--custom--spacing--small)) !important"
-					}
-				}
-			},
-			"core/post-featured-image": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
 			"core/post-title": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--small)",
-						"top": "var(--wp--custom--spacing--small)"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--custom--typography--font-size--huge)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.02em"
 				}
 			},
 			"core/pullquote": {
 				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
-					"style": "solid solid solid solid",
-					"width": "1px 0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--tertiary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/query-pagination": {
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--medium) !important"
-					}
-				}
-			},
-			"core/query-pagination-next": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-numbers": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
-				}
-			},
-			"core/query-pagination-previous": {
-				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)"
+					"color": "var(--wp--preset--color--primary)"
 				}
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
-				}
-			},
-			"core/quote": {
-				"border": {
-					"color": "var(--wp--preset--color--primary)",
-					"style": "solid",
-					"width": "0 0 0 1px"
-				},
-				"spacing": {
-					"margin": {
-						"bottom": "var(--wp--custom--spacing--large) !important",
-						"top": "var(--wp--custom--spacing--large) !important"
-					}
-				}
-			},
-			"core/separator": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)"
+					"letterSpacing": "0.02em"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--colossal)",
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--gigantic)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.01em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.01em"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--huge)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.02em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.02em"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.03em",
-					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
+					"letterSpacing": "0.03em"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.05em",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
+					"letterSpacing": "0.05em"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading)",
-					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
-					"letterSpacing": "0.05em",
-					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-					"textTransform": "uppercase"
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--preset--color--foreground)"
+					"letterSpacing": "0.05em"
 				}
 			}
 		},
 		"spacing": {
 			"blockGap": "2.5rem"
-		},
-		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--normal)",
-			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
 		}
-	},
-	"templateParts": [
-		{
-			"name": "header",
-			"title": "Header",
-			"area": "header"
-		},
-		{
-			"name": "footer",
-			"title": "Footer",
-			"area": "footer"
-		}
-	]
+	}
 }

--- a/theme.json
+++ b/theme.json
@@ -485,6 +485,7 @@
 			},
 			"h4": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--xx-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"

--- a/theme.json
+++ b/theme.json
@@ -161,6 +161,10 @@
 				}
 			}
 		},
+		"layout": {
+			"contentSize": "650px",
+			"wideSize": "80rem"
+		},
 		"spacing": {
 			"units": ["%", "px", "em", "rem", "vh", "vw"]
 		},
@@ -225,10 +229,6 @@
 					"slug": "colossal"
 				}
 			]
-		},
-		"layout": {
-			"contentSize": "650px",
-			"wideSize": "80rem"
 		}
 	},
 	"styles": {

--- a/theme.json
+++ b/theme.json
@@ -446,7 +446,7 @@
 					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--gigantic)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
 				}
 			},
 			"h3": {

--- a/theme.json
+++ b/theme.json
@@ -397,7 +397,7 @@
 					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
-					"lineHeight": "var(--wp--custom--typography--line-height--small)"
+					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
 				}
 			},
 			"core/quote": {

--- a/theme.json
+++ b/theme.json
@@ -300,26 +300,6 @@
 					"letterSpacing": "0"
 				}
 			},
-			"core/group": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
-			"core/image": {
-				"border": {
-					"radius": {
-						"bottomLeft": "0",
-						"bottomRight": "0",
-						"topLeft": "0",
-						"topRight": "0"
-					}
-				}
-			},
 			"core/navigation": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
@@ -375,12 +355,6 @@
 			"core/pullquote": {
 				"border": {
 					"color": "transparent",
-					"radius": {
-						"bottomLeft": "0px",
-						"bottomRight": "0px",
-						"topLeft": "0px",
-						"topRight": "0px"
-					},
 					"style": "solid",
 					"width": "1px 0"
 				},

--- a/theme.json
+++ b/theme.json
@@ -521,9 +521,9 @@
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--body)",
-			"lineHeight": "var(--wp--custom--typography--line-height--normal)",
 			"fontSize": "var(--wp--preset--font-size--medium)",
-			"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
+			"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
+			"lineHeight": "var(--wp--custom--typography--line-height--normal)"
 		}
 	},
 	"templateParts": [

--- a/theme.json
+++ b/theme.json
@@ -173,8 +173,8 @@
 			"fontFamilies": [
 				{
 					"fontFamily": "\"Inter\", sans-serif",
-					"name": "Body",
-					"slug": "body",
+					"name": "Body (Inter)",
+					"slug": "body-font",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
@@ -187,6 +187,11 @@
 							]
 						}
 					]
+				},
+				{
+					"fontFamily": "\"Inter\", sans-serif",
+					"name": "Headings (Inter)",
+					"slug": "heading-font"
 				}
 			],
 			"fontSizes": [
@@ -415,6 +420,7 @@
 			},
 			"core/query-title": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"lineHeight": "var(--wp--custom--typography--line-height--small)"
@@ -440,6 +446,7 @@
 			},
 			"core/site-title": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
@@ -453,6 +460,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"letterSpacing": "-0.03em",
@@ -461,6 +469,7 @@
 			},
 			"h2": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontSize": "var(--wp--preset--font-size--gigantic)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"lineHeight": "var(--wp--custom--typography--line-height--small)"
@@ -468,6 +477,7 @@
 			},
 			"h3": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
@@ -482,6 +492,7 @@
 			},
 			"h5": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
 					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
@@ -490,6 +501,7 @@
 			},
 			"h6": {
 				"typography": {
+					"fontFamily": "var(--wp--preset--font-family--heading-font)",
 					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
 					"letterSpacing": "0.03em",

--- a/theme.json
+++ b/theme.json
@@ -174,7 +174,7 @@
 				{
 					"fontFamily": "\"Inter\", sans-serif",
 					"name": "Body (Inter)",
-					"slug": "body-font",
+					"slug": "body",
 					"fontFace": [
 						{
 							"fontDisplay": "block",
@@ -191,7 +191,7 @@
 				{
 					"fontFamily": "\"Inter\", sans-serif",
 					"name": "Headings (Inter)",
-					"slug": "heading-font"
+					"slug": "headings"
 				}
 			],
 			"fontSizes": [
@@ -420,7 +420,7 @@
 			},
 			"core/query-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading-font)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"lineHeight": "var(--wp--custom--typography--line-height--small)"
@@ -446,7 +446,7 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading-font)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
@@ -460,7 +460,7 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading-font)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--colossal)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"letterSpacing": "-0.03em",
@@ -469,7 +469,7 @@
 			},
 			"h2": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading-font)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--gigantic)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"lineHeight": "var(--wp--custom--typography--line-height--small)"
@@ -477,7 +477,7 @@
 			},
 			"h3": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading-font)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--huge)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--bold)",
 					"lineHeight": "var(--wp--custom--typography--line-height--tiny)"
@@ -492,7 +492,7 @@
 			},
 			"h5": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading-font)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--x-large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
 					"lineHeight": "var(--wp--custom--typography--line-height--normal)",
@@ -501,7 +501,7 @@
 			},
 			"h6": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--heading-font)",
+					"fontFamily": "var(--wp--preset--font-family--headings)",
 					"fontSize": "var(--wp--preset--font-size--large)",
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
 					"letterSpacing": "0.03em",


### PR DESCRIPTION
Now that Launch is no longer relying on style variations being pulled in from an external source. We no longer need to duplicate all entries in each and every style variation.