### PR TITLE
Add dark mega footer & remove navigation ref ID

### DIFF
--- a/parts/footer-logo-nav.html
+++ b/parts/footer-logo-nav.html
@@ -16,7 +16,7 @@
 			</div>
 			<!-- /wp:group -->
 
-			<!-- wp:navigation {"ref":177,"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /-->
+			<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /-->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/parts/footer-mega.html
+++ b/parts/footer-mega.html
@@ -1,0 +1,95 @@
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"3rem"}},"backgroundColor":"foreground","textColor":"background","className":"ext-my-0 ext-pt-lg ext-pb-base","layout":{"inherit":true}} -->
+<div
+	class="wp-block-group alignfull ext-my-0 ext-pt-lg ext-pb-base has-background-color has-foreground-background-color has-text-color has-background"
+>
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"bottom":"1rem"},"blockGap":"3rem"}}} -->
+	<div class="wp-block-columns alignwide" style="padding-bottom: 1rem">
+		<!-- wp:column {"width":"33.3%","style":{"spacing":{"blockGap":"1.5rem"}}} -->
+		<div class="wp-block-column" style="flex-basis: 33.3%">
+			<!-- wp:site-title {"isLink":false,"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"fontSize":"large"} /-->
+
+			<!-- wp:site-tagline /-->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"style":{"spacing":{"blockGap":"1.5rem"}}} -->
+		<div class="wp-block-column">
+			<!-- wp:heading {"level":3,"fontSize":"medium"} -->
+			<h3 class="has-medium-font-size">Products</h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:navigation {"overlayMenu":"never","overlayTextColor":"foreground","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0.5rem"}}} /-->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"style":{"spacing":{"blockGap":"1.5rem"}}} -->
+		<div class="wp-block-column">
+			<!-- wp:heading {"level":3,"fontSize":"medium"} -->
+			<h3 class="has-medium-font-size">Articles</h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:navigation {"overlayMenu":"never","overlayTextColor":"foreground","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0.5rem"}}} /-->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"style":{"spacing":{"blockGap":"1.5rem"}}} -->
+		<div class="wp-block-column">
+			<!-- wp:heading {"level":3,"fontSize":"medium"} -->
+			<h3 class="has-medium-font-size">About</h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:navigation {"overlayMenu":"never","overlayTextColor":"foreground","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0.5rem"}}} /-->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+
+	<!-- wp:separator {"align":"full","style":{"color":{"background":"#ffffff1a"}},"className":"alignwide is-style-wide"} -->
+	<hr
+		class="wp-block-separator alignfull has-text-color has-alpha-channel-opacity has-background alignwide is-style-wide"
+		style="background-color: #ffffff1a; color: #ffffff1a"
+	/>
+	<!-- /wp:separator -->
+
+	<!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"blockGap":"2rem","padding":{"bottom":"1rem"}}}} -->
+	<div
+		class="wp-block-columns alignwide are-vertically-aligned-center"
+		style="padding-bottom: 1rem"
+	>
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+			<!-- wp:group {"layout":{"type":"flex","allowOrientation":false,"flexWrap":"wrap"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"fontSize":"small"} -->
+				<p class="has-small-font-size">© Your Company LLC</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+			<!-- wp:social-links {"iconColor":"white","iconColorValue":"#ffffff","size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"right"},"style":{"spacing":{"blockGap":{"top":"1.5rem","left":"1.5rem"}}}} -->
+			<ul
+				class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only"
+			>
+				<!-- wp:social-link {"url":"#","service":"facebook"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"twitter"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"linkedin"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"tiktok"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"youtube"} /-->
+			</ul>
+			<!-- /wp:social-links -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->

--- a/parts/footer-with-address-dark-three-columns.html
+++ b/parts/footer-with-address-dark-three-columns.html
@@ -24,7 +24,7 @@
 				<h3>About</h3>
 				<!-- /wp:heading -->
 
-				<!-- wp:navigation {"ref":66,"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"},"typography":{"fontSize":"1.25rem"}}} /-->
+				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"},"typography":{"fontSize":"1.25rem"}}} /-->
 			</div>
 			<!-- /wp:column -->
 
@@ -34,7 +34,7 @@
 				<h3>Follow</h3>
 				<!-- /wp:heading -->
 
-				<!-- wp:navigation {"ref":66,"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"},"typography":{"fontSize":"1.25rem"}}} /-->
+				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"0px"},"typography":{"fontSize":"1.25rem"}}} /-->
 			</div>
 			<!-- /wp:column -->
 		</div>

--- a/patterns/footer-call-to-action-dark.php
+++ b/patterns/footer-call-to-action-dark.php
@@ -30,7 +30,7 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"ref":177,"textColor":"secondary","overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header--nav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /--></div>
+<!-- wp:navigation {"textColor":"secondary","overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header--nav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/patterns/footer-call-to-action.php
+++ b/patterns/footer-call-to-action.php
@@ -39,7 +39,7 @@
 <h4 class="has-small-font-size" id="about">About</h4>
 <!-- /wp:heading -->
 
-<!-- wp:navigation {"ref":177,"overlayMenu":"never","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","flexWrap":"nowrap","orientation":"vertical"},"style":{"spacing":{"blockGap":"0.75rem"}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","flexWrap":"nowrap","orientation":"vertical"},"style":{"spacing":{"blockGap":"0.75rem"}}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"25%"} -->
@@ -47,7 +47,7 @@
 <h4 class="has-small-font-size" id="company-1">Products</h4>
 <!-- /wp:heading -->
 
-<!-- wp:navigation {"ref":177,"overlayMenu":"never","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","flexWrap":"nowrap","orientation":"vertical"},"style":{"spacing":{"blockGap":"0.75rem"}}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","flexWrap":"nowrap","orientation":"vertical"},"style":{"spacing":{"blockGap":"0.75rem"}}} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group --></div>

--- a/patterns/footer-logo-desc-two-nav.php
+++ b/patterns/footer-logo-desc-two-nav.php
@@ -30,7 +30,7 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"ref":177,"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /--></div>
+<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/patterns/footer-logo-nav.php
+++ b/patterns/footer-logo-nav.php
@@ -18,7 +18,7 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<!-- wp:navigation {"ref":177,"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /--></div>
+<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/patterns/header-title-nav-button.php
+++ b/patterns/header-title-nav-button.php
@@ -12,7 +12,7 @@
 <div class="wp-block-group"><!-- wp:site-title /-->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"ref":2515,"layout":{"type":"flex","justifyContent":"right","flexWrap":"nowrap"}} /-->
+<div class="wp-block-group"><!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","flexWrap":"nowrap"}} /-->
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button -->

--- a/theme.json
+++ b/theme.json
@@ -548,7 +548,7 @@
 		},
 		{
 			"name": "footer-mega",
-			"title": "Footer Mega Dark",
+			"title": "Footer with Three Columns of Menus",
 			"area": "footer"
 		}
 	]

--- a/theme.json
+++ b/theme.json
@@ -545,6 +545,11 @@
 			"name": "footer-with-address-dark-three-columns",
 			"title": "Footer with Address, Dark, Three Columns",
 			"area": "footer"
+		},
+		{
+			"name": "footer-mega",
+			"title": "Footer Mega Dark",
+			"area": "footer"
 		}
 	]
 }


### PR DESCRIPTION
Added a Dark Mega Footer:
![image](https://user-images.githubusercontent.com/32260742/180089184-86ee6fcf-487c-45b7-931b-996063f35060.png)

### Why need to remove the navigation ref ID?
Navigation ref ID is used to select the menu from the database. Navigation with ref ID throws a warning_ message `Navigation menu has been deleted or is unavailable.`

![image](https://user-images.githubusercontent.com/32260742/180090391-84b59ab9-dcf6-4a5a-9d0d-7b67cac2e9d3.png)

