### PR TITLE
WP 6.1 Preparation and backward compatibility

### DIFF
--- a/assets/css/deprecate-style.css
+++ b/assets/css/deprecate-style.css
@@ -10,17 +10,6 @@
  * https://github.com/WordPress/gutenberg/issues/35884
  */
 
- /* .wp-site-blocks,
- body > .is-root-container,
- .edit-post-visual-editor__post-title-wrapper,
- .wp-block-group.alignfull,
- .wp-block-group.has-background,
- .wp-block-cover.alignfull,
- .is-root-container .wp-block[data-align="full"] > .wp-block-group,
- .is-root-container .wp-block[data-align="full"] > .wp-block-cover {
-     padding-left: var(--wp--custom--spacing--outer);
-     padding-right: var(--wp--custom--spacing--outer);
- } */
  .block-editor-block-list__layout.is-root-container > .alignfull,
  .block-editor-block-list__layout.is-root-container > .alignfull > .alignfull,
  .is-root-container > .wp-block-group.has-background,

--- a/assets/css/deprecate-style.css
+++ b/assets/css/deprecate-style.css
@@ -1,0 +1,50 @@
+/*
+ * Alignment styles.
+ * These rules are temporary, and should not be relied on or
+ * modified too heavily by themes or plugins that build on
+ * Twenty Twenty-Two. These are meant to be a precursor to
+ * a global solution provided by the Block Editor.
+ *
+ * Relevant issues:
+ * https://github.com/WordPress/gutenberg/issues/35607
+ * https://github.com/WordPress/gutenberg/issues/35884
+ */
+
+ /* .wp-site-blocks,
+ body > .is-root-container,
+ .edit-post-visual-editor__post-title-wrapper,
+ .wp-block-group.alignfull,
+ .wp-block-group.has-background,
+ .wp-block-cover.alignfull,
+ .is-root-container .wp-block[data-align="full"] > .wp-block-group,
+ .is-root-container .wp-block[data-align="full"] > .wp-block-cover {
+     padding-left: var(--wp--custom--spacing--outer);
+     padding-right: var(--wp--custom--spacing--outer);
+ } */
+ .block-editor-block-list__layout.is-root-container > .alignfull,
+ .block-editor-block-list__layout.is-root-container > .alignfull > .alignfull,
+ .is-root-container > .wp-block-group.has-background,
+ .wp-site-blocks .alignfull,
+ .wp-site-blocks > .wp-block-group.has-background,
+ .wp-site-blocks > .wp-block-cover,
+ .wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
+ .wp-site-blocks > .wp-block-template-part > .wp-block-cover,
+ body > .is-root-container > .wp-block-cover,
+ body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
+ body > .is-root-container > .wp-block-template-part > .wp-block-cover,
+ .is-root-container .wp-block[data-align="full"] {
+     margin-right: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
+     margin-left: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
+     width: unset;
+ }
+ 
+ /* Blocks inside columns don't have negative margins. */
+ .wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
+ .is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
+ /* We also want to avoid stacking negative margins. */
+ .wp-site-blocks .alignfull:not(.wp-block-group) .alignfull,
+ .is-root-container .wp-block[data-align="full"] > *:not(.wp-block-group) .wp-block[data-align="full"] {
+     margin-left: auto !important;
+     margin-right: auto !important;
+     width: inherit;
+ }

--- a/assets/css/deprecate-style.css
+++ b/assets/css/deprecate-style.css
@@ -9,31 +9,42 @@
  * https://github.com/WordPress/gutenberg/issues/35607
  * https://github.com/WordPress/gutenberg/issues/35884
  */
+.wp-site-blocks,
+body>.is-root-container,
+.edit-post-visual-editor__post-title-wrapper,
+.wp-block-group.alignfull,
+.wp-block-group.has-background,
+.wp-block-cover.alignfull,
+.is-root-container .wp-block[data-align="full"]>.wp-block-group,
+.is-root-container .wp-block[data-align="full"]>.wp-block-cover {
+    padding-left: clamp(1.5rem, 5vw, 2rem);
+    padding-right: clamp(1.5rem, 5vw, 2rem);
+}
 
- .block-editor-block-list__layout.is-root-container > .alignfull,
- .block-editor-block-list__layout.is-root-container > .alignfull > .alignfull,
- .is-root-container > .wp-block-group.has-background,
- .wp-site-blocks .alignfull,
- .wp-site-blocks > .wp-block-group.has-background,
- .wp-site-blocks > .wp-block-cover,
- .wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
- .wp-site-blocks > .wp-block-template-part > .wp-block-cover,
- body > .is-root-container > .wp-block-cover,
- body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
- body > .is-root-container > .wp-block-template-part > .wp-block-cover,
- .is-root-container .wp-block[data-align="full"] {
-     margin-right: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
-     margin-left: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
-     width: unset;
- }
- 
- /* Blocks inside columns don't have negative margins. */
- .wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
- .is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
- /* We also want to avoid stacking negative margins. */
- .wp-site-blocks .alignfull:not(.wp-block-group) .alignfull,
- .is-root-container .wp-block[data-align="full"] > *:not(.wp-block-group) .wp-block[data-align="full"] {
-     margin-left: auto !important;
-     margin-right: auto !important;
-     width: inherit;
- }
+.block-editor-block-list__layout.is-root-container>.alignfull,
+.block-editor-block-list__layout.is-root-container>.alignfull>.alignfull,
+.is-root-container>.wp-block-group.has-background,
+.wp-site-blocks .alignfull,
+.wp-site-blocks>.wp-block-group.has-background,
+.wp-site-blocks>.wp-block-cover,
+.wp-site-blocks>.wp-block-template-part>.wp-block-group.has-background,
+.wp-site-blocks>.wp-block-template-part>.wp-block-cover,
+body>.is-root-container>.wp-block-cover,
+body>.is-root-container>.wp-block-template-part>.wp-block-group.has-background,
+body>.is-root-container>.wp-block-template-part>.wp-block-cover,
+.is-root-container .wp-block[data-align="full"] {
+    margin-right: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
+    margin-left: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
+    width: unset;
+}
+
+/* Blocks inside columns don't have negative margins. */
+.wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
+.is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
+/* We also want to avoid stacking negative margins. */
+.wp-site-blocks .alignfull:not(.wp-block-group) .alignfull,
+.is-root-container .wp-block[data-align="full"]>*:not(.wp-block-group) .wp-block[data-align="full"] {
+    margin-left: auto !important;
+    margin-right: auto !important;
+    width: inherit;
+}

--- a/functions.php
+++ b/functions.php
@@ -68,6 +68,10 @@ if ( ! function_exists( 'extendable_styles' ) ) :
 		// Enqueue theme stylesheet.
 		wp_enqueue_style( 'extendable-style' );
 
+		global $wp_version;
+		if(version_compare( $wp_version, '6.0.2', '<=' )) {
+			wp_add_inline_style( 'extendable-style', extendable_backward_compatibilitye_styles() );
+		};
 	}
 
 endif;
@@ -144,3 +148,70 @@ if ( ! function_exists( 'is_woocommerce_activated' ) ) {
 	}
 	add_filter( 'woocommerce_enqueue_styles', 'extendable_woocommerce_enqueue_styles' );
 }
+
+if ( ! function_exists( 'extendable_inline_editor_styles' ) ) :
+
+	/**
+	 * Enqueue editor styles.
+	 *
+	 * @since Extendable 1.1.0
+	 *
+	 * @return void
+	 */
+	function extendable_inline_editor_styles() {
+
+		// Add editor styles inline.
+		global $wp_version;
+		if(version_compare( $wp_version, '6.0.2', '<=' )) {
+			wp_add_inline_style( 'wp-block-library', extendable_backward_compatibilitye_styles() );
+		}
+	}
+
+endif;
+
+add_action( 'admin_init', 'extendable_inline_editor_styles' );
+if ( ! function_exists( 'extendable_backward_compatibilitye_styles' ) ) :
+
+	/**
+	 * Get editor styles.
+	 *
+	 * @since Extendable 1.1.0
+	 *
+	 * @return string
+	 */
+	function extendable_backward_compatibilitye_styles() {
+
+		return "
+			/*
+			* Alignment styles.
+			* These rules are temporary, and should not be relied on or
+			* modified too heavily by themes or plugins that build on
+			* Twenty Twenty-Two. These are meant to be a precursor to
+			* a global solution provided by the Block Editor.
+			*
+			* Relevant issues:
+			* https://github.com/WordPress/gutenberg/issues/35607
+			* https://github.com/WordPress/gutenberg/issues/35884
+			*/
+		
+		   .block-editor-block-list__layout.is-root-container > .alignfull,
+		   .block-editor-block-list__layout.is-root-container > .alignfull > .alignfull,
+		   .is-root-container > .wp-block-group.has-background,
+		   .wp-site-blocks .alignfull,
+		   .wp-site-blocks > .wp-block-group.has-background,
+		   .wp-site-blocks > .wp-block-cover,
+		   .wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
+		   .wp-site-blocks > .wp-block-template-part > .wp-block-cover,
+		   body > .is-root-container > .wp-block-cover,
+		   body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
+		   body > .is-root-container > .wp-block-template-part > .wp-block-cover,
+		   .is-root-container .wp-block[data-align=\"full\"] {
+				margin-right: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
+				margin-left: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
+				width: unset;
+		   }
+		";
+
+	}
+
+endif;

--- a/functions.php
+++ b/functions.php
@@ -22,8 +22,18 @@ if ( ! function_exists( 'extendable_support' ) ) :
 		// Add support for block styles.
 		add_theme_support( 'wp-block-styles' );
 
+		global $wp_version;
+		// Add style for WordPress older versions.
+		if(version_compare( $wp_version, '6.0.2', '<=' )) {
+			$editor_style = array(
+				'style.css',
+				'/assets/css/deprecate-style.css',
+			);
+		} else {
+			$editor_style = 'style.css';
+		}
 		// Enqueue editor styles.
-		add_editor_style( 'style.css' );
+		add_editor_style( $editor_style );
 
 		// Register WooCommerce theme features.
 		add_theme_support( 'wc-product-gallery-zoom' );
@@ -70,7 +80,15 @@ if ( ! function_exists( 'extendable_styles' ) ) :
 
 		global $wp_version;
 		if(version_compare( $wp_version, '6.0.2', '<=' )) {
-			wp_add_inline_style( 'extendable-style', extendable_backward_compatibilitye_styles() );
+			// Register deprecate stylesheet.
+			wp_register_style(
+				'extendable-deprecate-style',
+				get_template_directory_uri() . '/assets/css/deprecate-style.css',
+				array(),
+				$version_string
+			);
+			// Enqueue deprecate stylesheet.
+			wp_enqueue_style( 'extendable-deprecate-style' );
 		};
 	}
 
@@ -148,70 +166,3 @@ if ( ! function_exists( 'is_woocommerce_activated' ) ) {
 	}
 	add_filter( 'woocommerce_enqueue_styles', 'extendable_woocommerce_enqueue_styles' );
 }
-
-if ( ! function_exists( 'extendable_inline_editor_styles' ) ) :
-
-	/**
-	 * Enqueue editor styles.
-	 *
-	 * @since Extendable 1.1.0
-	 *
-	 * @return void
-	 */
-	function extendable_inline_editor_styles() {
-
-		// Add editor styles inline.
-		global $wp_version;
-		if(version_compare( $wp_version, '6.0.2', '<=' )) {
-			wp_add_inline_style( 'wp-block-library', extendable_backward_compatibilitye_styles() );
-		}
-	}
-
-endif;
-
-add_action( 'admin_init', 'extendable_inline_editor_styles' );
-if ( ! function_exists( 'extendable_backward_compatibilitye_styles' ) ) :
-
-	/**
-	 * Get editor styles.
-	 *
-	 * @since Extendable 1.1.0
-	 *
-	 * @return string
-	 */
-	function extendable_backward_compatibilitye_styles() {
-
-		return "
-			/*
-			* Alignment styles.
-			* These rules are temporary, and should not be relied on or
-			* modified too heavily by themes or plugins that build on
-			* Twenty Twenty-Two. These are meant to be a precursor to
-			* a global solution provided by the Block Editor.
-			*
-			* Relevant issues:
-			* https://github.com/WordPress/gutenberg/issues/35607
-			* https://github.com/WordPress/gutenberg/issues/35884
-			*/
-		
-		   .block-editor-block-list__layout.is-root-container > .alignfull,
-		   .block-editor-block-list__layout.is-root-container > .alignfull > .alignfull,
-		   .is-root-container > .wp-block-group.has-background,
-		   .wp-site-blocks .alignfull,
-		   .wp-site-blocks > .wp-block-group.has-background,
-		   .wp-site-blocks > .wp-block-cover,
-		   .wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
-		   .wp-site-blocks > .wp-block-template-part > .wp-block-cover,
-		   body > .is-root-container > .wp-block-cover,
-		   body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
-		   body > .is-root-container > .wp-block-template-part > .wp-block-cover,
-		   .is-root-container .wp-block[data-align=\"full\"] {
-				margin-right: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
-				margin-left: calc(clamp(1.5rem, 5vw, 2rem) * -1) !important;
-				width: unset;
-		   }
-		";
-
-	}
-
-endif;

--- a/parts/footer-logo-nav.html
+++ b/parts/footer-logo-nav.html
@@ -1,25 +1,21 @@
-<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull">
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)"}}},"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"footer","align":"full"} -->
+<footer class="wp-block-group alignfull">
+	<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0rem","padding":{"top":"clamp(1.5rem, 5vw, 2rem)","right":"clamp(1.5rem, 5vw, 2rem)","bottom":"clamp(1.5rem, 5vw, 2rem)","left":"clamp(1.5rem, 5vw, 2rem)"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group alignfull"
-		style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--small, 1.25rem)">
-		<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0rem"}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group alignfull">
-			<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
-			<div class="wp-block-group">
-				<!-- wp:site-title {"width":48,"className":"is-style-rounded"} /-->
+		style="padding-top:clamp(1.5rem, 5vw, 2rem);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:clamp(1.5rem, 5vw, 2rem);padding-left:clamp(1.5rem, 5vw, 2rem)">
+		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-title {"className":"is-style-rounded"} /-->
 
-				<!-- wp:paragraph {"align":"right","fontSize":"small"} -->
-				<p class="has-text-align-right has-small-font-size">Proudly powered by <a
-						href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-				<!-- /wp:paragraph -->
-			</div>
-			<!-- /wp:group -->
-
-			<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /-->
+			<!-- wp:paragraph {"align":"right","fontSize":"small"} -->
+			<p class="has-text-align-right has-small-font-size">Proudly powered by <a href="https://wordpress.org"
+					rel="nofollow">WordPress</a></p>
+			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
+
+		<!-- wp:navigation {"ref":85,"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /-->
 	</div>
 	<!-- /wp:group -->
-</div>
+</footer>
 <!-- /wp:group -->

--- a/parts/header-title-nav-button.html
+++ b/parts/header-title-nav-button.html
@@ -1,29 +1,22 @@
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)"}}},"layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull"
-	style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--small, 1.25rem)">
-	<!-- wp:group {"align":"full"} -->
-	<div class="wp-block-group alignfull">
-		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"clamp(1.5rem, 5vw, 2rem)","right":"clamp(1.5rem, 5vw, 2rem)","bottom":"clamp(1.5rem, 5vw, 2rem)","left":"clamp(1.5rem, 5vw, 2rem)"}}}} -->
+<div class="wp-block-group alignfull" style="padding-top:clamp(1.5rem, 5vw, 2rem);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:clamp(1.5rem, 5vw, 2rem);padding-left:clamp(1.5rem, 5vw, 2rem)">
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
+
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
 		<div class="wp-block-group">
-			<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
+			<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
+			<!-- wp:page-list /-->
+			<!-- /wp:navigation -->
 
-			<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
-			<div class="wp-block-group">
-
-				<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
-					<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-				<!-- /wp:navigation -->
-
-				<!-- wp:buttons -->
-				<div class="wp-block-buttons">
-					<!-- wp:button -->
-					<div class="wp-block-button"><a class="wp-block-button__link">Get Started</a>
-					</div>
-					<!-- /wp:button -->
-				</div>
-				<!-- /wp:buttons -->
+			<!-- wp:buttons -->
+			<div class="wp-block-buttons">
+				<!-- wp:button -->
+				<div class="wp-block-button"><a class="wp-block-button__link">Get Started</a></div>
+				<!-- /wp:button -->
 			</div>
-			<!-- /wp:group -->
+			<!-- /wp:buttons -->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/parts/header-title-social-nav.html
+++ b/parts/header-title-social-nav.html
@@ -1,37 +1,32 @@
-<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull">
-	<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)"}}},"layout":{"inherit":true}} -->
+<!-- wp:group {"tagName":"header","align":"full","layout":{"inherit":true,"type":"constrained"}} -->
+<header class="wp-block-group alignfull">
+	<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0rem","padding":{"top":"clamp(1.5rem, 5vw, 2rem)","right":"clamp(1.5rem, 5vw, 2rem)","bottom":"clamp(1.5rem, 5vw, 2rem)","left":"clamp(1.5rem, 5vw, 2rem)"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group alignfull"
-		style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--small, 1.25rem)">
-		<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0rem"}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group alignfull">
-			<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}},"layout":{"type":"flex","allowOrientation":false}} -->
-			<div class="wp-block-group">
-				<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
-			</div>
-			<!-- /wp:group -->
+		style="padding-top:clamp(1.5rem, 5vw, 2rem);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:clamp(1.5rem, 5vw, 2rem);padding-left:clamp(1.5rem, 5vw, 2rem)">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}},"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
+		</div>
+		<!-- /wp:group -->
 
-			<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
-			<div class="wp-block-group">
-				<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(--wp--preset--color--foreground)","size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"1rem"}}} -->
-				<ul
-					class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only">
-					<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+			<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(\u002d\u002dwp\u002d\u002dpreset\u002d\u002dcolor\u002d\u002dforeground)","size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"1rem"}}} -->
+			<ul class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only">
+				<!-- wp:social-link {"url":"#","service":"instagram"} /-->
 
-					<!-- wp:social-link {"url":"#","service":"facebook"} /-->
+				<!-- wp:social-link {"url":"#","service":"facebook"} /-->
 
-					<!-- wp:social-link {"url":"#","service":"twitter"} /-->
-				</ul>
-				<!-- /wp:social-links -->
+				<!-- wp:social-link {"url":"#","service":"twitter"} /-->
+			</ul>
+			<!-- /wp:social-links -->
 
-				<!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"primary","overlayTextColor":"secondary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
-				<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-				<!-- /wp:navigation -->
-			</div>
-			<!-- /wp:group -->
+			<!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"primary","overlayTextColor":"secondary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
+			<!-- wp:page-list /-->
+			<!-- /wp:navigation -->
 		</div>
 		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
-</div>
+</header>
 <!-- /wp:group -->

--- a/patterns/footer-logo-nav.php
+++ b/patterns/footer-logo-nav.php
@@ -7,18 +7,24 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)"}}},"layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--small, 1.25rem)"><!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0rem"}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
-<div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
-<div class="wp-block-group"><!-- wp:site-title {"width":48,"className":"is-style-rounded"} /-->
+<!-- wp:group {"tagName":"footer","align":"full"} -->
+<footer class="wp-block-group alignfull">
+	<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0rem","padding":{"top":"clamp(1.5rem, 5vw, 2rem)","right":"clamp(1.5rem, 5vw, 2rem)","bottom":"clamp(1.5rem, 5vw, 2rem)","left":"clamp(1.5rem, 5vw, 2rem)"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group alignfull"
+		style="padding-top:clamp(1.5rem, 5vw, 2rem);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:clamp(1.5rem, 5vw, 2rem);padding-left:clamp(1.5rem, 5vw, 2rem)">
+		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-title {"className":"is-style-rounded"} /-->
 
-<!-- wp:paragraph {"align":"right","fontSize":"small"} -->
-<p class="has-text-align-right has-small-font-size">Proudly powered by <a href="https://wordpress.org" rel="nofollow">WordPress</a></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
+			<!-- wp:paragraph {"align":"right","fontSize":"small"} -->
+			<p class="has-text-align-right has-small-font-size">Proudly powered by <a href="https://wordpress.org"
+					rel="nofollow">WordPress</a></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
 
-<!-- wp:navigation {"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
+		<!-- wp:navigation {"ref":85,"overlayBackgroundColor":"foreground","overlayTextColor":"background","className":"header\u002d\u002dnav order-3 md:order-2","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"}} /-->
+	</div>
+	<!-- /wp:group -->
+</footer>
 <!-- /wp:group -->

--- a/patterns/header-title-nav-button.php
+++ b/patterns/header-title-nav-button.php
@@ -8,10 +8,17 @@
 ?>
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"clamp(1.5rem, 5vw, 2rem)","right":"clamp(1.5rem, 5vw, 2rem)","bottom":"clamp(1.5rem, 5vw, 2rem)","left":"clamp(1.5rem, 5vw, 2rem)"}}}} -->
-<div class="wp-block-group alignfull" style="padding-top:clamp(1.5rem, 5vw, 2rem);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:clamp(1.5rem, 5vw, 2rem);padding-left:clamp(1.5rem, 5vw, 2rem)">
+<div class="wp-block-group alignfull"
+	style="padding-top:clamp(1.5rem, 5vw, 2rem);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:clamp(1.5rem, 5vw, 2rem);padding-left:clamp(1.5rem, 5vw, 2rem)">
 	<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 	<div class="wp-block-group">
-		<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-logo {"width":120} /-->
+
+			<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
+		</div>
+		<!-- /wp:group -->
 
 		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
 		<div class="wp-block-group">

--- a/patterns/header-title-nav-button.php
+++ b/patterns/header-title-nav-button.php
@@ -7,19 +7,28 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)"}}},"layout":{"inherit":true}} --><div class="wp-block-group alignfull" style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--small, 1.25rem)"><!-- wp:group {"align":"full"} -->
-<div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group"><!-- wp:site-title /-->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"clamp(1.5rem, 5vw, 2rem)","right":"clamp(1.5rem, 5vw, 2rem)","bottom":"clamp(1.5rem, 5vw, 2rem)","left":"clamp(1.5rem, 5vw, 2rem)"}}}} -->
+<div class="wp-block-group alignfull" style="padding-top:clamp(1.5rem, 5vw, 2rem);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:clamp(1.5rem, 5vw, 2rem);padding-left:clamp(1.5rem, 5vw, 2rem)">
+	<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group">
+		<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
 
-<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group"><!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","flexWrap":"nowrap"}} /-->
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap"}} -->
+		<div class="wp-block-group">
+			<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
+			<!-- wp:page-list /-->
+			<!-- /wp:navigation -->
 
-<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button -->
-<div class="wp-block-button"><a class="wp-block-button__link">Get Started</a></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
+			<!-- wp:buttons -->
+			<div class="wp-block-buttons">
+				<!-- wp:button -->
+				<div class="wp-block-button"><a class="wp-block-button__link">Get Started</a></div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+</div>
 <!-- /wp:group -->

--- a/patterns/header-title-social-nav.php
+++ b/patterns/header-title-social-nav.php
@@ -14,6 +14,7 @@
 		style="padding-top:clamp(1.5rem, 5vw, 2rem);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:clamp(1.5rem, 5vw, 2rem);padding-left:clamp(1.5rem, 5vw, 2rem)">
 		<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}},"layout":{"type":"flex","allowOrientation":false}} -->
 		<div class="wp-block-group">
+			<!-- wp:site-logo {"width":120} /-->
 			<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/header-title-social-nav.php
+++ b/patterns/header-title-social-nav.php
@@ -7,26 +7,35 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dsmall, 1.25rem)"}}},"layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--custom--spacing--small, 1.25rem);padding-bottom:var(--wp--custom--spacing--small, 1.25rem)"><!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0rem"}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
-<div class="wp-block-group alignfull"><!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}},"layout":{"type":"flex","allowOrientation":false}} -->
-<div class="wp-block-group"><!-- wp:site-title /--></div>
-<!-- /wp:group -->
+<!-- wp:group {"tagName":"header","align":"full","layout":{"inherit":true,"type":"constrained"}} -->
+<header class="wp-block-group alignfull">
+	<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0rem","padding":{"top":"clamp(1.5rem, 5vw, 2rem)","right":"clamp(1.5rem, 5vw, 2rem)","bottom":"clamp(1.5rem, 5vw, 2rem)","left":"clamp(1.5rem, 5vw, 2rem)"}}},"layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group alignfull"
+		style="padding-top:clamp(1.5rem, 5vw, 2rem);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:clamp(1.5rem, 5vw, 2rem);padding-left:clamp(1.5rem, 5vw, 2rem)">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"1.5rem"}},"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
+		</div>
+		<!-- /wp:group -->
 
-<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
-<div class="wp-block-group"><!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(--wp--preset--color--foreground)","size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"1rem"}}} -->
-<ul class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"#","service":"instagram"} /-->
+		<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
+		<div class="wp-block-group">
+			<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(\u002d\u002dwp\u002d\u002dpreset\u002d\u002dcolor\u002d\u002dforeground)","size":"has-small-icon-size","className":"is-style-logos-only","layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"1rem"}}} -->
+			<ul class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only">
+				<!-- wp:social-link {"url":"#","service":"instagram"} /-->
 
-<!-- wp:social-link {"url":"#","service":"facebook"} /-->
+				<!-- wp:social-link {"url":"#","service":"facebook"} /-->
 
-<!-- wp:social-link {"url":"#","service":"twitter"} /--></ul>
-<!-- /wp:social-links -->
+				<!-- wp:social-link {"url":"#","service":"twitter"} /-->
+			</ul>
+			<!-- /wp:social-links -->
 
-<!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"primary","overlayTextColor":"secondary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
-<!-- wp:page-list /-->
-<!-- /wp:navigation --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
+			<!-- wp:navigation {"overlayMenu":"always","overlayBackgroundColor":"primary","overlayTextColor":"secondary","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
+			<!-- wp:page-list /-->
+			<!-- /wp:navigation -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+</header>
 <!-- /wp:group -->

--- a/style.css
+++ b/style.css
@@ -20,6 +20,16 @@ Extendable WordPress Theme, (C) 2022 Extendify Inc.
 Extendable therefore is also distributed under the terms of the GNU GPL.
 */
 
+
+/* Fallback for deprecate variables.
+---------------------------------------------------------------------------- */
+:root {
+	--wp--custom--spacing--small: var(--wp--preset--spacing--30, clamp(1.5rem, 5vw, 2rem));
+	--wp--custom--spacing--medium: var(--wp--preset--spacing--50, clamp(2.5rem, 8vw, 4rem));
+	--wp--custom--spacing--large: var(--wp--preset--spacing--60, clamp(2.5rem, 8vw, 6rem));
+	--wp--custom--spacing--outer: max(1.25rem, 4vw);
+}
+
 /*
  * Font smoothing.
  * This is a niche setting that will not be available via Global Styles.

--- a/style.css
+++ b/style.css
@@ -102,57 +102,6 @@ nav .wp-block-pages-list__item.wp-block-navigation-item.menu-item-home {
 }
 
 /*
- * Alignment styles.
- * These rules are temporary, and should not be relied on or
- * modified too heavily by themes or plugins that build on
- * Twenty Twenty-Two. These are meant to be a precursor to
- * a global solution provided by the Block Editor.
- *
- * Relevant issues:
- * https://github.com/WordPress/gutenberg/issues/35607
- * https://github.com/WordPress/gutenberg/issues/35884
- */
-
-.wp-site-blocks,
-body > .is-root-container,
-.edit-post-visual-editor__post-title-wrapper,
-.wp-block-group.alignfull,
-.wp-block-group.has-background,
-.wp-block-cover.alignfull,
-.is-root-container .wp-block[data-align="full"] > .wp-block-group,
-.is-root-container .wp-block[data-align="full"] > .wp-block-cover {
-	padding-left: var(--wp--custom--spacing--outer);
-	padding-right: var(--wp--custom--spacing--outer);
-}
-.block-editor-block-list__layout.is-root-container > .alignfull,
-.block-editor-block-list__layout.is-root-container > .alignfull > .alignfull,
-.is-root-container > .wp-block-group.has-background,
-.wp-site-blocks .alignfull,
-.wp-site-blocks > .wp-block-group.has-background,
-.wp-site-blocks > .wp-block-cover,
-.wp-site-blocks > .wp-block-template-part > .wp-block-group.has-background,
-.wp-site-blocks > .wp-block-template-part > .wp-block-cover,
-body > .is-root-container > .wp-block-cover,
-body > .is-root-container > .wp-block-template-part > .wp-block-group.has-background,
-body > .is-root-container > .wp-block-template-part > .wp-block-cover,
-.is-root-container .wp-block[data-align="full"] {
-	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
-	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;
-	width: unset;
-}
-
-/* Blocks inside columns don't have negative margins. */
-.wp-site-blocks .wp-block-columns .wp-block-column .alignfull,
-.is-root-container .wp-block-columns .wp-block-column .wp-block[data-align="full"],
-/* We also want to avoid stacking negative margins. */
-.wp-site-blocks .alignfull:not(.wp-block-group) .alignfull,
-.is-root-container .wp-block[data-align="full"] > *:not(.wp-block-group) .wp-block[data-align="full"] {
-	margin-left: auto !important;
-	margin-right: auto !important;
-	width: inherit;
-}
-
-/*
  * Responsive menu container padding.
  * This ensures the responsive container inherits the same
  * spacing defined above. This behavior may be built into

--- a/theme.json
+++ b/theme.json
@@ -150,12 +150,6 @@
 					}
 				}
 			},
-			"spacing": {
-				"small": "min(2rem, 3.5vw)",
-				"medium": "calc(2 * var(--wp--custom--spacing--small))",
-				"large": "min(6rem, 10vw)",
-				"outer": "max(1.25rem, 4vw)"
-			},
 			"typography": {
 				"fontSmoothing": {
 					"moz": "grayscale",
@@ -545,7 +539,7 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "var:custom|spacing|small",
+			"blockGap": "var(--wp--preset--spacing--30, clamp(1.5rem, 5vw, 2rem))",
 			"padding": {
 				"top": "var(--wp--preset--spacing--40)",
 				"right": "var(--wp--preset--spacing--30)",

--- a/theme.json
+++ b/theme.json
@@ -139,6 +139,7 @@
 				}
 			]
 		},
+		"useRootPaddingAwareAlignments": true,
 		"custom": {
 			"blocks": {
 				"core/table": {
@@ -185,6 +186,41 @@
 			"wideSize": "80rem"
 		},
 		"spacing": {
+			"spacingScale": {
+				"steps": 0
+			},
+			"spacingSizes": [
+				{
+					"size": "clamp(1.5rem, 5vw, 2rem)",
+					"slug": "30",
+					"name": "1"
+				},
+				{
+					"size": "clamp(1.8rem, 1.8rem + ((1vw - 0.48rem) * 2.885), 3rem)",
+					"slug": "40",
+					"name": "2"
+				},
+				{
+					"size": "clamp(2.5rem, 8vw, 4rem)",
+					"slug": "50",
+					"name": "3"
+				},
+				{
+					"size": "clamp(2.5rem, 8vw, 6rem)",
+					"slug": "60",
+					"name": "4"
+				},
+				{
+					"size": "clamp(3.75rem, 10vw, 7rem)",
+					"slug": "70",
+					"name": "5"
+				},
+				{
+					"size": "clamp(5rem, 5.25rem + ((1vw - 0.48rem) * 9.096), 8rem)",
+					"slug": "80",
+					"name": "6"
+				}
+			],
 			"units": ["%", "px", "em", "rem", "vh", "vw"]
 		},
 		"typography": {
@@ -509,7 +545,13 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "var:custom|spacing|small"
+			"blockGap": "var:custom|spacing|small",
+			"padding": {
+				"top": "var(--wp--preset--spacing--40)",
+				"right": "var(--wp--preset--spacing--30)",
+				"bottom": "var(--wp--preset--spacing--40)",
+				"left": "var(--wp--preset--spacing--30)"
+			}
 		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--body)",

--- a/theme.json
+++ b/theme.json
@@ -542,9 +542,9 @@
 			"blockGap": "2rem",
 			"padding": {
 				"top": "0",
-				"right": "var(--wp--preset--spacing--30, clamp(1.5rem, 5vw, 2rem))",
+				"right": "var(--wp--preset--spacing--30)",
 				"bottom": "0",
-				"left": "var(--wp--preset--spacing--30, clamp(1.5rem, 5vw, 2rem))"
+				"left": "var(--wp--preset--spacing--30)"
 			}
 		},
 		"typography": {

--- a/theme.json
+++ b/theme.json
@@ -139,7 +139,6 @@
 				}
 			]
 		},
-		"useRootPaddingAwareAlignments": true,
 		"custom": {
 			"blocks": {
 				"core/table": {
@@ -268,7 +267,8 @@
 					"slug": "xx-large"
 				}
 			]
-		}
+		},
+		"useRootPaddingAwareAlignments": true
 	},
 	"styles": {
 		"blocks": {
@@ -539,12 +539,12 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "var(--wp--preset--spacing--30, clamp(1.5rem, 5vw, 2rem))",
+			"blockGap": "2rem",
 			"padding": {
-				"top": "var(--wp--preset--spacing--40)",
-				"right": "var(--wp--preset--spacing--30)",
-				"bottom": "var(--wp--preset--spacing--40)",
-				"left": "var(--wp--preset--spacing--30)"
+				"top": "0",
+				"right": "var(--wp--preset--spacing--30, clamp(1.5rem, 5vw, 2rem))",
+				"bottom": "0",
+				"left": "var(--wp--preset--spacing--30, clamp(1.5rem, 5vw, 2rem))"
 			}
 		},
 		"typography": {


### PR DESCRIPTION
This PR adds support of new WordPress 6.1 features through the theme.json and makes sure backward compatibility (WP 6.0 to 6.0.2)

- Introduce step spacing for.
  - block gap
  - block padding
  - block margin 
- Introduce [root padding  ](https://make.wordpress.org/themes/2022/09/07/full-width-blocks-and-root-padding-in-wordpress-6-1/)


WIP