### PR TITLE
Apply mix-blend-mode to default logo

### DIFF
--- a/style.css
+++ b/style.css
@@ -147,6 +147,12 @@ blockquote:is(.is-style-plain) {
     width: auto !important;
 }
 
+/* Ensure default logo works well on light and dark backgrounds
+----------------------------------------------------------*/
+.wp-block-site-logo img[src*="extendify-demo-"] {
+	mix-blend-mode: difference;
+}
+
 /* Responsive menu animation and customization.
 ----------------------------------------------------------*/
 @media (max-width: 599px) {


### PR DESCRIPTION
Previous https://github.com/extendify/extendify-sdk/pull/1422#issuecomment-1525903718.

This applies mix-blend-mode on the default logo to ensure that the default logo will appear well on both light and dark backgrounds. 
