### PR TITLE
Fixing Character Issues in Tokyo Variation Heading Fonts

### DIFF
--- a/styles/tokyo.json
+++ b/styles/tokyo.json
@@ -72,7 +72,7 @@
 		"blocks": {
 			"core/comments-title": {
 				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
 					"letterSpacing": "0.03em"
 				}
 			},
@@ -83,7 +83,7 @@
 			},
 			"core/site-title": {
 				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
 					"letterSpacing": "0.02em"
 				}
 			}
@@ -91,42 +91,43 @@
 		"elements": {
 			"h1": {
 				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)"
 				}
 			},
 			"h2": {
 				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
 					"letterSpacing": "0.01em"
 				}
 			},
 			"h3": {
 				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
 					"letterSpacing": "0.02em"
 				}
 			},
 			"h4": {
 				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
 					"letterSpacing": "0.03em"
 				}
 			},
 			"h5": {
 				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
 					"letterSpacing": "0.05em"
 				}
 			},
 			"h6": {
 				"typography": {
-					"fontWeight": "var(--wp--custom--typography--font-weight--regular)",
+					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
 					"letterSpacing": "0.05em"
 				}
 			},
 			"heading": {
 				"typography": {
-					"fontFamily": "var(--wp--preset--font-family--koulen)"
+					"fontFamily": "var(--wp--preset--font-family--koulen)",
+					"textTransform": "uppercase"
 				}
 			}
 		},


### PR DESCRIPTION
Discussion for the PR is [here](https://github.com/extendify/company-product/issues/899).

This PR fixes the issue where the 'Koulen' font was not supporting certain characters in the 'Tokyo' style variation.






