### PR TITLE
Add compatibility support for Contact Form 7 and WPForms

### DIFF
--- a/assets/css/contact-form-7.css
+++ b/assets/css/contact-form-7.css
@@ -1,0 +1,54 @@
+.wpcf7 input:where(:not([type="submit"]):not([type="checkbox"])) {
+	border: 1px solid;
+	line-height: inherit;
+	font-size: inherit;
+}
+.wpcf7 input:where(:not([type="submit"]):not([type="checkbox"])),
+.wpcf7 textarea {
+	padding: calc(0.667em + 1px);
+	width: 100%;
+	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
+	border-color: inherit;
+}
+
+.wpcf7-form-control-wrap {
+	margin-top: 0.25em;
+	display: block;
+}
+
+.wpcf7 input[type="submit"] {
+	background-color: var(--wp--custom--elements--button--color--background);
+	color: var(--wp--custom--elements--button--color--text);
+	border-radius: var(--wp--custom--elements--button--border--radius);
+	border-width: 0;
+	font-family: inherit;
+	font-size: inherit;
+	font-weight: var(--wp--custom--typography--font-weight--medium);
+	line-height: inherit;
+	padding-top: calc(0.667em + 2px);
+	padding-right: calc(1.333em + 2px);
+	padding-bottom: calc(0.667em + 2px);
+	padding-left: calc(1.333em + 2px);
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.wpcf7 input[type="submit"]:hover {
+	background-color: var(
+		--wp--custom--elements--button--hover--color--background
+	);
+	color: var(--wp--custom--elements--button--hover--color--text);
+}
+
+.wpcf7 input[type="submit"]:focus {
+	background-color: var(
+		--wp--custom--elements--button--focus--color--background
+	);
+	color: var(--wp--custom--elements--button--focus--color--text);
+	outline-color: var(--wp--custom--elements--button--focus--color--background);
+	offset: 2px;
+	outline-width: 1px;
+	outline-offset: 2px;
+	outline-style: solid;
+}

--- a/assets/css/wpforms.css
+++ b/assets/css/wpforms.css
@@ -1,0 +1,57 @@
+.wpforms-block.wpforms-container .wpforms-field-label {
+	font-weight: inherit;
+	margin-bottom: 0.25em;
+}
+.wpforms-block input:where(:not([type="submit"]):not([type="checkbox"])) {
+	border: 1px solid;
+	line-height: inherit;
+	font-size: inherit;
+}
+.wpforms-block input:where(:not([type="submit"]):not([type="checkbox"])),
+.wpforms-block textarea {
+	padding: calc(0.667em + 1px);
+	width: 100%;
+	background-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--foreground);
+	border-color: inherit;
+}
+.wpforms-field-sublabel {
+	opacity: 0.8;
+}
+
+.wpforms-block button.wpforms-submit {
+	background-color: var(--wp--custom--elements--button--color--background);
+	color: var(--wp--custom--elements--button--color--text);
+	border-radius: var(--wp--custom--elements--button--border--radius);
+	border-width: 0;
+	font-family: inherit;
+	font-size: inherit;
+	font-weight: var(--wp--custom--typography--font-weight--medium);
+	line-height: inherit;
+	padding-top: calc(0.667em + 2px);
+	padding-right: calc(1.333em + 2px);
+	padding-bottom: calc(0.667em + 2px);
+	padding-left: calc(1.333em + 2px);
+	text-decoration: none;
+	cursor: pointer;
+	margin-top: 1rem;
+}
+
+.wpforms-block button.wpforms-submit:hover {
+	background-color: var(
+		--wp--custom--elements--button--hover--color--background
+	);
+	color: var(--wp--custom--elements--button--hover--color--text);
+}
+
+.wpforms-block button.wpforms-submit:focus {
+	background-color: var(
+		--wp--custom--elements--button--focus--color--background
+	);
+	color: var(--wp--custom--elements--button--focus--color--text);
+	outline-color: var(--wp--custom--elements--button--focus--color--background);
+	offset: 2px;
+	outline-width: 2px;
+	outline-offset: 2px;
+	outline-style: solid;
+}

--- a/functions.php
+++ b/functions.php
@@ -85,6 +85,36 @@ endif;
 add_action( 'wp_enqueue_scripts', 'extendable_styles' );
 
 /**
+ * Enqueue block-specific styles.
+ *
+ * @since Extendable 2.0.11
+ *
+ * @return void
+ */
+function extendable_enqueue_block_styles() {
+	// Check for specific blocks and enqueue their styles
+	if ( has_block( 'contact-form-7/contact-form-selector' ) ) {
+		wp_enqueue_style(
+			'extendable-contact-form-7-style',
+			get_template_directory_uri() . '/assets/css/contact-form-7.css',
+			array(),
+			'1.0.0'
+		);
+	}
+
+	if ( has_block( 'wpforms/form-selector' ) ) {
+		wp_enqueue_style(
+			'extendable-wpforms-style',
+			get_template_directory_uri() . '/assets/css/wpforms.css',
+			array(),
+			'1.0.0'
+		);
+	}
+}
+
+add_action( 'enqueue_block_assets', 'extendable_enqueue_block_styles' );
+
+/**
  * Registers pattern categories.
  *
  * @since Extendable 1.0

--- a/style.css
+++ b/style.css
@@ -58,6 +58,11 @@ a:focus {
 	text-decoration-style: var(--wp--custom--elements--link--interactive--text-decoration-style, dashed);
 }
 
+:where(.wp-site-blocks *:focus) {
+	outline-width:1px;
+	outline-style:solid
+}
+
 a:active {
 	text-decoration: none;
 }
@@ -185,40 +190,19 @@ blockquote:is(.is-style-plain) {
 /*
  * Matching caret and focus outline colors.
  */
-input {
+input, textarea {
 	caret-color: inherit;
-	outline-color: var(--wp--preset--color--tertiary);
-	outline-offset: 0.2ch;
-}
-
-.wp-block-post-comments input:not([type="submit"]),
-.wp-block-post-comments input:not([type="submit"]):not([type="checkbox"]),
-.wp-block-post-comments textarea
- {
-	background-color: var(--wp--custom--elements--input--color--background);
-	color: var(--wp--custom--elements--input--color--text);
-    border-color: var(--wp--custom--elements--input--border--color);
-    border-radius: var(--wp--custom--elements--input--border--radius);
-    border-width: var(--wp--custom--elements--input--border--width);
-    display: block;
-    font-size: var(--wp--custom--elements--input--typography--font-size);
-    line-height: var(--wp--custom--elements--input--typography--line-height);
-    padding: var(--wp--custom--elements--input--spacing--padding--top) var(--wp--custom--elements--input--spacing--padding--right) var(--wp--custom--elements--input--spacing--padding--bottom) var(--wp--custom--elements--input--spacing--padding--left);
-    width: 100%;
+	outline-color: inherit;
 }
 
 /*
  * Matching input with outline button style.
  */
-.wp-block-post-comments-form input:not([type=submit]),
-.wp-block-post-comments-form textarea {
-    border: 2px solid currentColor;
-    padding: 0.667em 1.333em !important;
-	font-size: 1.15rem;
-    line-height: 1.384;
-	border-radius: 0.5rem;
+:where(.wp-block-post-comments-form) input:not([type=submit]), 
+:where(.wp-block-post-comments-form) textarea {
 	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);
+	border-color: inherit;
 }
 
 

--- a/styles/bloom.json
+++ b/styles/bloom.json
@@ -68,50 +68,7 @@
 			"elements": {
 				"button": {
 					"border": {
-						"radius": "0.4rem",
-						"color": "var(--wp--preset--color--secondary)",
-						"width": "1px"
-					},
-					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--foreground)"
-					},
-					"spacing": {
-						"padding": {
-							"top": "calc(0.838rem - 1px)",
-							"right": "calc(2.5rem - 1px)",
-							"bottom": "calc(0.838rem - 1px)",
-							"left": "calc(2.5rem - 1px)"
-						}
-					},
-					"typography": {
-						"fontSize": "1.0625rem",
-						"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-						"lineHeight": "var(--wp--custom--typography--line-height--normal)"
-					}
-				},
-				"input": {
-					"border": {
-						"radius": "0.4rem",
-						"width": "1px",
-						"color": "var(--wp--preset--color--foreground)"
-					},
-					"color": {
-						"background": "var(--wp--preset--color--background)",
-						"text": "var(--wp--preset--color--foreground)"
-					},
-					"spacing": {
-						"padding": {
-							"top": "calc(0.838rem - 1px)",
-							"right": "calc(1rem - 1px)",
-							"bottom": "calc(0.838rem - 1px)",
-							"left": "calc(1rem - 1px)"
-						}
-					},
-					"typography": {
-						"fontSize": "1.0625rem",
-						"fontWeight": "var(--wp--custom--font-weight--regular)",
-						"lineHeight": "var(--wp--custom--typography--line-height--normal)"
+						"radius": "0.4rem"
 					}
 				}
 			}
@@ -140,8 +97,8 @@
 		"elements": {
 			"button": {
 				"border": {
-					"radius": "0.4rem"
-				},			
+					"radius": "var(--wp--custom--elements--button--border--radius)"
+				},
 				"spacing": {
 					"padding": {
 						"top": "0.838rem",

--- a/styles/fusion-sky.json
+++ b/styles/fusion-sky.json
@@ -68,26 +68,23 @@
 			"elements": {
 				"button": {
 					"border": {
-						"radius": "2rem",
-						"color": "var(--wp--preset--color--secondary)",
-						"width": "2px"
+						"radius": "2rem"
 					},
 					"color": {
 						"background": "var(--wp--preset--color--secondary)",
 						"text": "var(--wp--preset--color--foreground)"
 					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 2px)",
-							"left": "calc(1.333em + 2px)",
-							"right": "calc(1.333em + 2px)",
-							"top": "calc(0.667em + 2px)"
+					":hover": {
+						"color": {
+							"background": "var(--wp--preset--color--foreground)",
+							"text": "var(--wp--preset--color--background)"
 						}
 					},
-					"typography": {
-						"fontSize": "1.125rem",
-						"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-						"lineHeight": "var(--wp--custom--typography--line-height--normal)"
+					":focus": {
+						"color": {
+							"background": "var(--wp--preset--color--foreground)",
+							"text": "var(--wp--preset--color--background)"
+						}
 					}
 				},
 				"input": {
@@ -122,22 +119,6 @@
 			"text": "var(--wp--preset--color--foreground-alt)"
 		},
 		"elements": {
-			"button": {
-				"color": {
-					"background": "var(--wp--preset--color--secondary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				"typography": {
-					"fontSize": "inherit",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "inherit"
-				},
-				":visited": {
-					"color": {
-						"text": "var(--wp--preset--color--foreground)"
-					}
-				}
-			},
 			"h1": {
 				"typography": {
 					"fontWeight": "400"

--- a/styles/gdansk.json
+++ b/styles/gdansk.json
@@ -58,15 +58,6 @@
 					"name": "Background Alt"
 				}
 			]
-		},
-		"custom": {
-			"elements": {
-				"button": {
-					"color": {
-						"text": "var(--wp--preset--color--background)"
-					}
-				}
-			}
 		}
 	},
 	"styles": {

--- a/styles/graphite.json
+++ b/styles/graphite.json
@@ -44,12 +44,12 @@
 				},
 				{
 					"slug": "primary",
-					"color": "#000000",
+					"color": "#292929",
 					"name": "Primary"
 				},
 				{
 					"slug": "secondary",
-					"color": "#262626",
+					"color": "#303030",
 					"name": "Secondary"
 				},
 				{
@@ -57,7 +57,7 @@
 					"color": "#E9E8E6",
 					"name": "Tertiary"
 				},
-                {
+				{
 					"slug": "foreground-alt",
 					"color": "#444444",
 					"name": "Foreground Alt"
@@ -68,92 +68,33 @@
 			"elements": {
 				"button": {
 					"border": {
-						"radius": "2rem",
-						"color": "var(--wp--preset--color--secondary)",
-						"width": "2px"
+						"radius": "2rem"
 					},
 					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--foreground)"
+						"background": "var(--wp--preset--color--foreground)",
+						"text": "var(--wp--preset--color--background)"
 					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 2px)",
-							"left": "calc(1.333em + 2px)",
-							"right": "calc(1.333em + 2px)",
-							"top": "calc(0.667em + 2px)"
+					":hover": {
+						"color": {
+							"background": "var(--wp--preset--color--secondary)",
+							"text": "var(--wp--preset--color--background)"
 						}
 					},
-					"typography": {
-						"fontSize": "1.125rem",
-						"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-						"lineHeight": "var(--wp--custom--typography--line-height--normal)"
-					}
-				},
-				"input": {
-					"border": {
-						"radius": "4px",
-						"width": "1px",
-						"color": "var(--wp--preset--color--foreground)"
-					},
-					"color": {
-						"background": "var(--wp--preset--color--background)",
-						"text": "var(--wp--preset--color--foreground)"
-					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 1px)",
-							"left": "calc(1.333em + 1px)",
-							"right": "calc(1.333em + 1px)",
-							"top": "calc(0.667em + 1px)"
+					":focus": {
+						"color": {
+							"background": "var(--wp--preset--color--foreground)",
+							"text": "var(--wp--preset--color--background)"
 						}
-					},
-					"typography": {
-						"fontSize": "inherit",
-						"fontWeight": "var(--wp--custom--font-weight--regular)",
-						"lineHeight": "var(--wp--custom--typography--line-height--normal)"
 					}
 				}
 			}
 		}
 	},
 	"styles": {
-		"blocks": {
-			"core/button": {
-				"variations": {
-					"outline": {
-						"spacing": {
-							"padding": {
-								"top": "calc(0.838rem - 1px)",
-								"right": "calc(2rem - 1px)",
-								"bottom": "calc(0.838rem - 1px)",
-								"left": "calc(2rem - 1px)"
-							}
-						}
-					}
-				}
-			}
-		},
 		"color": {
 			"text": "var(--wp--preset--color--foreground-alt)"
 		},
 		"elements": {
-			
-			"button": {
-				"spacing": {
-					"padding": {
-						"top": "0.838rem",
-						"right": "2rem",
-						"bottom": "0.838rem",
-						"left": "2rem"
-					}
-				},
-				"typography": {
-					"fontSize": "1.0625rem",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "inherit"
-				}
-			},
 			"heading": {
 				"color": {
 					"text": "var(--wp--preset--color--foreground)"

--- a/styles/hong-kong.json
+++ b/styles/hong-kong.json
@@ -39,7 +39,7 @@
 				},
 				{
 					"slug": "primary",
-					"color": "#A30026",
+					"color": "#860000",
 					"name": "Primary"
 				},
 				{
@@ -58,32 +58,23 @@
 			"elements": {
 				"button": {
 					"border": {
-						"radius": "8px",
-						"color": "var(--wp--preset--color--primary)",
-						"width": "2px"
+						"radius": "0.5rem"
 					},
 					"color": {
-						"background": "var(--wp--preset--color--primary)",
-						"text": "var(--wp--preset--color--tertiary)"
+						"background": "var(--wp--preset--color--foreground)",
+						"text": "var(--wp--preset--color--background)"
 					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 2px)",
-							"left": "calc(1.333em + 2px)",
-							"right": "calc(1.333em + 2px)",
-							"top": "calc(0.667em + 2px)"
+					":hover": {
+						"color": {
+							"background": "var(--wp--preset--color--primary)",
+							"text": "var(--wp--preset--color--background)"
 						}
 					},
-					"typography": {
-						"fontSize": "var(--wp--preset--font-size--small)",
-						"textTransform": "uppercase",
-						"letterSpacing": "0.15rem",
-						"fontWeight": "400"
-					}
-				},
-				"input": {
-					"border": {
-						"radius": "8px"
+					":focus": {
+						"color": {
+							"background": "var(--wp--preset--color--foreground)",
+							"text": "var(--wp--preset--color--background)"
+						}
 					}
 				}
 			},
@@ -131,32 +122,11 @@
 		},
 		"elements": {
 			"button": {
-				"border": {
-					"radius": "0.5rem"
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)",
 					"textTransform": "uppercase",
 					"letterSpacing": "0.15rem",
 					"fontWeight": "400"
-				},
-				":hover": {
-					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--primary)"
-					}
-				},
-				":focus": {
-					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--primary)"
-					}
-				},
-				":active": {
-					"color": {
-						"background": "var(--wp--preset--color--primary)",
-						"text": "var(--wp--preset--color--background)"
-					}
 				}
 			},
 			"h1": {

--- a/styles/kampala.json
+++ b/styles/kampala.json
@@ -66,12 +66,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"color": {
-					"background": "var(--wp--preset--color--primary)",
-					"text": "var(--wp--preset--color--white)"
-				}
-			},
 			"core/separator": {
 				"color": {
 					"text": "var(--wp--preset--color--primary)"
@@ -79,11 +73,6 @@
 			}
 		},
 		"elements": {
-			"button": {
-				"border": {
-					"radius": "0.5rem"
-				}
-			},
 			"h1": {
 				"typography": {
 					"letterSpacing": "-0.01em"

--- a/styles/lagoon.json
+++ b/styles/lagoon.json
@@ -63,58 +63,6 @@
 					"name": "Foreground Alt"
 				}
 			]
-		},
-		"custom": {
-			"elements": {
-				"button": {
-					"border": {
-						"radius": "2rem",
-						"color": "var(--wp--preset--color--secondary)",
-						"width": "2px"
-					},
-					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--foreground)"
-					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 2px)",
-							"left": "calc(1.333em + 2px)",
-							"right": "calc(1.333em + 2px)",
-							"top": "calc(0.667em + 2px)"
-						}
-					},
-					"typography": {
-						"fontSize": "1.125rem",
-						"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-						"lineHeight": "var(--wp--custom--typography--line-height--normal)"
-					}
-				},
-				"input": {
-					"border": {
-						"radius": "4px",
-						"width": "1px",
-						"color": "var(--wp--preset--color--foreground)"
-					},
-					"color": {
-						"background": "var(--wp--preset--color--background)",
-						"text": "var(--wp--preset--color--foreground)"
-					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 1px)",
-							"left": "calc(1.333em + 1px)",
-							"right": "calc(1.333em + 1px)",
-							"top": "calc(0.667em + 1px)"
-						}
-					},
-					"typography": {
-						"fontSize": "inherit",
-						"fontWeight": "var(--wp--custom--font-weight--regular)",
-						"lineHeight": "var(--wp--custom--typography--line-height--normal)"
-					}
-				}
-			}
 		}
 	},
 	"styles": {
@@ -122,12 +70,6 @@
 			"text": "var(--wp--preset--color--foreground-alt)"
 		},
 		"elements": {
-            "button": {
-                "typography": {
-                    "fontSize": "var(--wp--preset--font-size--small)",
-                    "fontWeight": "600"
-                }
-            },
 			"heading": {
                 "color": {
 					"text": "var(--wp--preset--color--foreground)"

--- a/styles/odesa.json
+++ b/styles/odesa.json
@@ -44,7 +44,7 @@
 				},
 				{
 					"slug": "primary",
-					"color": "#0b0449",
+					"color": "#070f79",
 					"name": "Primary"
 				},
 				{
@@ -68,14 +68,7 @@
 			"elements": {
 				"button": {
 					"border": {
-						"radius": "2px",
-						"width": "1px"
-					}
-				},
-				"input": {
-					"border": {
-						"radius": "2px",
-						"width": "1px"
+						"radius": "2px"
 					}
 				}
 			}
@@ -132,14 +125,6 @@
 			"text": "var(--wp--preset--color--foreground-alt)"
 		},
 		"elements": {
-			"button": {
-				"border": {
-					"radius": "2px"
-				},
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--small)"
-				}
-			},
 			"h1": {
 				"typography": {
 					"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",

--- a/styles/onyx.json
+++ b/styles/onyx.json
@@ -44,7 +44,7 @@
 				},
 				{
 					"slug": "primary",
-					"color": "#FFFCFC",
+					"color": "#FFFFFF",
 					"name": "Primary"
 				},
 				{
@@ -63,91 +63,19 @@
 			"elements": {
 				"button": {
 					"border": {
-						"radius": "2rem",
-						"color": "var(--wp--preset--color--secondary)",
-						"width": "2px"
+						"radius": "0.2rem"
 					},
-					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--foreground)"
-					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 2px)",
-							"left": "calc(1.333em + 2px)",
-							"right": "calc(1.333em + 2px)",
-							"top": "calc(0.667em + 2px)"
+					":hover": {
+						"color": {
+							"background": "var(--wp--preset--color--secondary)"
 						}
-					},
-					"typography": {
-						"fontSize": "1.125rem",
-						"fontWeight": "var(--wp--custom--typography--font-weight--semi-bold)",
-						"lineHeight": "var(--wp--custom--typography--line-height--normal)"
-					}
-				},
-				"input": {
-					"border": {
-						"radius": "4px",
-						"width": "1px",
-						"color": "var(--wp--preset--color--foreground)"
-					},
-					"color": {
-						"background": "var(--wp--preset--color--background)",
-						"text": "var(--wp--preset--color--foreground)"
-					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 1px)",
-							"left": "calc(1.333em + 1px)",
-							"right": "calc(1.333em + 1px)",
-							"top": "calc(0.667em + 1px)"
-						}
-					},
-					"typography": {
-						"fontSize": "inherit",
-						"fontWeight": "var(--wp--custom--font-weight--regular)",
-						"lineHeight": "var(--wp--custom--typography--line-height--normal)"
 					}
 				}
 			}
 		}
 	},
 	"styles": {
-		"blocks": {
-			"core/button": {
-				"variations": {
-					"outline": {
-						"spacing": {
-							"padding": {
-								"top": "calc(0.838rem - 1px)",
-								"right": "calc(2.5rem - 1px)",
-								"bottom": "calc(0.838rem - 1px)",
-								"left": "calc(2.5rem - 1px)"
-							}
-						}
-					}
-				}
-			}
-		},
 		"elements": {
-			"button": {
-				"border": {
-					"radius": "0.2rem"
-				},	
-				"spacing": {
-					"padding": {
-						"top": "0.838rem",
-						"right": "2.5rem",
-						"bottom": "0.838rem",
-						"left": "2.5rem"
-					}
-				},
-				"typography": {
-					"fontSize": "1.0625rem",
-					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",
-					"lineHeight": "inherit"
-				}
-			},
 			"h1": {
 				"typography": {
 					"fontWeight": "500"

--- a/styles/orange.json
+++ b/styles/orange.json
@@ -58,33 +58,7 @@
 			"elements": {
 				"button": {
 					"border": {
-						"radius": "0",
-						"color": "var(--wp--preset--color--primary)",
-						"width": "2px"
-					},
-					"color": {
-						"background": "var(--wp--preset--color--primary)",
-						"text": "var(--wp--preset--color--white)"
-					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 2px)",
-							"left": "calc(1.333em + 2px)",
-							"right": "calc(1.333em + 2px)",
-							"top": "calc(0.667em + 2px)"
-						}
-					},
-					"typography": {
-						"fontSize": "1.15rem",
-						"fontWeight": "var(--wp--custom--font-weight--regular)",
-						"lineHeight": "1.384"
-					}
-				},
-				"input": {
-					"border": {
-						"radius": "0",
-						"width": "1px",
-						"color": "var(--wp--preset--color--foreground)"
+						"radius": "2px"
 					}
 				}
 			}
@@ -136,29 +110,6 @@
 	},
 	"styles": {
 		"elements": {
-			"button": {
-				"border": {
-					"radius": "2px"
-				},
-				":hover": {
-					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--background)"
-					}
-				},
-				":focus": {
-					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--background)"
-					}
-				},
-				":active": {
-					"color": {
-						"background": "var(--wp--preset--color--foreground)",
-						"text": "var(--wp--preset--color--background)"
-					}
-				}
-			},
 			"h1": {
 				"typography": {
 					"fontWeight": "700",

--- a/styles/piraeus.json
+++ b/styles/piraeus.json
@@ -74,6 +74,16 @@
 				"button": {
 					"border": {
 						"radius": "0"
+					},
+					"color": {
+						"background": "var(--wp--preset--color--primary)",
+						"text": "var(--wp--preset--color--foreground)"
+					},
+					":focus": {
+						"color": {
+							"background": "var(--wp--preset--color--primary)",
+							"text": "var(--wp--preset--color--foreground)"
+						}
 					}
 				}
 			},
@@ -112,26 +122,6 @@
 			}
 		},
 		"elements": {
-			"button": {
-				"border": {
-					"radius": "0"
-				},
-				"color": {
-					"background": "var(--wp--preset--color--primary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				":active": {
-					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--foreground)"
-					}
-				},
-				":visited": {
-					"color": {
-						"text": "var(--wp--preset--color--foreground)"
-					}
-				}
-			},
 			"h1": {
 				"typography": {
 					"fontWeight": "var(--wp--custom--typography--font-weight--light)",

--- a/styles/rio.json
+++ b/styles/rio.json
@@ -65,6 +65,26 @@
 					"moz": "auto",
 					"webkit": "auto"
 				}
+			},
+			"elements": {
+				"button": {
+					"color": {
+						"background": "var(--wp--preset--color--secondary)",
+						"text": "var(--wp--preset--color--foreground)"
+					},
+					":hover": {
+						"color": {
+							"background": "var(--wp--preset--color--primary)",
+							"text": "var(--wp--preset--color--background)"
+						}
+					},
+					":focus": {
+						"color": {
+							"background": "var(--wp--preset--color--secondary)",
+							"text": "var(--wp--preset--color--foreground)"
+						}
+					}
+				}
 			}
 		}
 	},
@@ -92,35 +112,6 @@
 			}
 		},
 		"elements": {
-			"button": {
-				"color": {
-					"background": "var(--wp--preset--color--secondary)",
-					"text": "var(--wp--preset--color--foreground)"
-				},
-				":hover": {
-					"color": {
-						"background": "var(--wp--preset--color--primary)",
-						"text": "var(--wp--preset--color--background)"
-					}
-				},
-				":focus": {
-					"color": {
-						"background": "var(--wp--preset--color--primary)",
-						"text": "var(--wp--preset--color--background)"
-					}
-				},
-				":active": {
-					"color": {
-						"background": "var(--wp--preset--color--foreground)",
-						"text": "var(--wp--preset--color--background)"
-					}
-				},
-				":visited": {
-					"color": {
-						"text": "var(--wp--preset--color--foreground)"
-					}
-				}
-			},
 			"h1": {
 				"typography": {
 					"fontWeight": "var(--wp--custom--typography--font-weight--regular)"

--- a/styles/santa-fe.json
+++ b/styles/santa-fe.json
@@ -44,7 +44,7 @@
 				},
 				{
 					"slug": "primary",
-					"color": "#1f033b",
+					"color": "#2c0453",
 					"name": "Primary"
 				},
 				{

--- a/styles/thimphu.json
+++ b/styles/thimphu.json
@@ -65,6 +65,26 @@
 					"moz": "auto",
 					"webkit": "auto"
 				}
+			},
+			"elements": {
+				"button": {
+					"color": {
+						"background": "var(--wp--preset--color--secondary)",
+						"text": "var(--wp--preset--color--background)"
+					},
+					":hover": {
+						"color": {
+							"background": "var(--wp--preset--color--foreground)",
+							"text": "var(--wp--preset--color--background)"
+						}
+					},
+					":focus": {
+						"color": {
+							"background": "var(--wp--preset--color--foreground)",
+							"text": "var(--wp--preset--color--background)"
+						}
+					}
+				}
 			}
 		}
 	},
@@ -85,30 +105,6 @@
 			}
 		},
 		"elements": {
-			"button": {
-				"color": {
-					"background": "var(--wp--preset--color--secondary)",
-					"text": "var(--wp--preset--color--background)"
-				},
-				":hover": {
-					"color": {
-						"background": "var(--wp--preset--color--foreground)",
-						"text": "var(--wp--preset--color--background)"
-					}
-				},
-				":focus": {
-					"color": {
-						"background": "var(--wp--preset--color--foreground)",
-						"text": "var(--wp--preset--color--background)"
-					}
-				},
-				":active": {
-					"color": {
-						"background": "var(--wp--preset--color--secondary)",
-						"text": "var(--wp--preset--color--foreground)"
-					}
-				}
-			},
 			"h1": {
 				"typography": {
 					"fontWeight": "var(--wp--custom--typography--font-weight--medium)",

--- a/theme.json
+++ b/theme.json
@@ -163,26 +163,11 @@
 			"elements": {
 				"button": {
 					"border": {
-						"radius": "2rem",
-						"color": "var(--wp--preset--color--primary)",
-						"width": "2px"
+						"radius": "2rem"
 					},
 					"color": {
 						"background": "var(--wp--preset--color--primary)",
 						"text": "var(--wp--preset--color--background)"
-					},
-					"spacing": {
-						"padding": {
-							"bottom": "calc(0.667em + 2px)",
-							"left": "calc(1.333em + 2px)",
-							"right": "calc(1.333em + 2px)",
-							"top": "calc(0.667em + 2px)"
-						}
-					},
-					"typography": {
-						"fontSize": "1.15rem",
-						"fontWeight": "var(--wp--custom--font-weight--regular)",
-						"lineHeight": "1.384"
 					},
 					":hover": {
 						"color": {
@@ -192,18 +177,7 @@
 					},
 					":focus": {
 						"color": {
-							"background": "var(--wp--preset--color--foreground)",
-							"text": "var(--wp--preset--color--background)"
-						}
-					},
-					":active": {
-						"color": {
 							"background": "var(--wp--preset--color--primary)",
-							"text": "var(--wp--preset--color--background)"
-						}
-					},
-					":visited": {
-						"color": {
 							"text": "var(--wp--preset--color--background)"
 						}
 					}
@@ -777,17 +751,6 @@
 	},
 	"styles": {
 		"blocks": {
-			"core/button": {
-				"variations": {
-					"outline": {
-						"border": {
-							"color": "currentColor",
-							"style": "solid",
-							"width": "1px"
-						}
-					}
-				}
-			},
 			"core/comment-content": {
 				"spacing": {
 					"margin": {
@@ -985,11 +948,11 @@
 		"elements": {
 			"button": {
 				"border": {
-					"radius": "2rem"
+					"radius": "var(--wp--custom--elements--button--border--radius)"
 				},
 				"color": {
-					"background": "var(--wp--preset--color--primary)",
-					"text": "var(--wp--preset--color--background)"
+					"background": "var(--wp--custom--elements--button--color--background)",
+					"text": "var(--wp--custom--elements--button--color--text)"
 				},
 				"typography": {
 					"fontSize": "inherit",
@@ -998,25 +961,24 @@
 				},
 				":hover": {
 					"color": {
-						"background": "var(--wp--preset--color--foreground)",
-						"text": "var(--wp--preset--color--background)"
+						"background": "var(--wp--custom--elements--button--hover--color--background)",
+						"text": "var(--wp--custom--elements--button--hover--color--text)"
 					}
 				},
 				":focus": {
 					"color": {
-						"background": "var(--wp--preset--color--foreground)",
-						"text": "var(--wp--preset--color--background)"
+						"background": "var(--wp--custom--elements--button--focus--color--background)",
+						"text": "var(--wp--custom--elements--button--focus--color--text)"
+					},
+					"outline": {
+						"color": "var(--wp--custom--elements--button--focus--color--background)",
+						"offset": "2px"
 					}
 				},
 				":active": {
 					"color": {
-						"background": "var(--wp--preset--color--primary)",
-						"text": "var(--wp--preset--color--background)"
-					}
-				},
-				":visited": {
-					"color": {
-						"text": "var(--wp--preset--color--background)"
+						"background": "var(--wp--custom--elements--button--hover--color--background)",
+						"text": "var(--wp--custom--elements--button--hover--color--text)"
 					}
 				}
 			},


### PR DESCRIPTION
This PR adds CSS to make the theme compatible with Contact Form 7 and WPForms.


Here are some examples of how the forms from the Contact Form 7 and WPForms plugins look with this PR.

<img width="1448" alt="Screenshot 2024-08-08 at 2 51 32 AM" src="https://github.com/user-attachments/assets/d42664b0-2ef8-4d91-ab40-9306ea350b23">
<img width="1589" alt="Screenshot 2024-08-08 at 2 51 56 AM" src="https://github.com/user-attachments/assets/58ceef5a-bae2-436a-ba61-714cbc124eaa">
<img width="1595" alt="Screenshot 2024-08-08 at 2 52 07 AM" src="https://github.com/user-attachments/assets/5d05fec0-5318-4d36-8033-5afc3b02bb09">
