### PR TITLE
Wrap Nav Block in Group for WooCommerce Icon Alignment

### DIFF
--- a/parts/header-with-center-nav-and-social.html
+++ b/parts/header-with-center-nav-and-social.html
@@ -11,10 +11,14 @@
         </div>
         <!-- /wp:group -->
 
-        <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
-        <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-        <!-- /wp:navigation -->
-
+        <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+                <div class="wp-block-group">
+                    <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
+                    <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
+                    <!-- /wp:navigation -->
+                </div>
+        <!-- /wp:group -->
+     
         <!-- wp:social-links {"iconColor":"foreground","iconColorValue":"var(\u002d\u002dwp\u002d\u002dpreset\u002d\u002dcolor\u002d\u002dforeground)","size":"has-small-icon-size","style":{"spacing":{"blockGap":"1rem"}},"className":"is-style-logos-only ext-hidden tablet:ext-flex","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
         <ul
             class="wp-block-social-links has-small-icon-size has-icon-color is-style-logos-only ext-hidden tablet:ext-flex">

--- a/theme.json
+++ b/theme.json
@@ -11,6 +11,11 @@
 			"name": "no-title",
 			"title": "No Title",
 			"postTypes": ["page", "post"]
+		},
+		{
+			"name": "no-title-sticky-header",
+			"title": "No Title Sticky Header",
+			"postTypes": ["page", "post"]
 		}
 	],
 	"settings": {


### PR DESCRIPTION
This PR does the following:
- Wrap the navigation block of the “Header with Center Nav and Social” header in a group block to align the WooCommerce icons properly.
- Add the label for no-title-sticky-header template.
