### PR TITLE
[Fix] Adds space to Fusion Sky theme name

### DIFF
--- a/styles/fusion-sky.json
+++ b/styles/fusion-sky.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
-	"title": "FusionSky",
+	"title": "Fusion Sky",
 	"version": 2,
 	"settings": {
 		"color": {


### PR DESCRIPTION
### Problem

Currently, in `fusion-sky.json` style file, the name is set to `FusionSky`.

### Solution

This fix changes it to `Fusion Sky`.

<!-- Explain the approach or steps taken to resolve the problem. -->

### How to Test

Use this branch locally and visit `Appearance -> Editor -> Styles`, and the name of the style should be now `Fusion Sky`.

### Blockages for Merge

@amjadr360 Can you think of any issue pushing this? Any potential dependency on this field from other repos?


**Note:** I'm updating this because when building the AI Styles feature I had to specifically support this style name in the server since it doesn't follow the same casing as the other ones.