### PR TITLE
Updates the schema version in `theme.json` files

### DIFF
--- a/styles/bloom.json
+++ b/styles/bloom.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Bloom",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/brisbane.json
+++ b/styles/brisbane.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
-	"version": 2,
+	"version": 3,
 	"title": "Brisbane",
 	"settings": {
 		"color": {

--- a/styles/cairo.json
+++ b/styles/cairo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
-	"version": 2,
 	"title": "Cairo",
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/fusion-sky.json
+++ b/styles/fusion-sky.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "FusionSky",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/gdansk.json
+++ b/styles/gdansk.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Gdansk",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/glasgow.json
+++ b/styles/glasgow.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Glasgow",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/graphite.json
+++ b/styles/graphite.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Graphite",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/hong-kong.json
+++ b/styles/hong-kong.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Hong Kong",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/kampala.json
+++ b/styles/kampala.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Kampala",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/lagoon.json
+++ b/styles/lagoon.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Lagoon",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [
@@ -57,7 +57,7 @@
 					"color": "#faf7f8",
 					"name": "Tertiary"
 				},
-                {
+				{
 					"slug": "foreground-alt",
 					"color": "#292929",
 					"name": "Foreground Alt"
@@ -71,7 +71,7 @@
 		},
 		"elements": {
 			"heading": {
-                "color": {
+				"color": {
 					"text": "var(--wp--preset--color--foreground)"
 				},
 				"typography": {

--- a/styles/odesa.json
+++ b/styles/odesa.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Odesa",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/onyx.json
+++ b/styles/onyx.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Onyx",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/orange.json
+++ b/styles/orange.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Orange",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/piraeus.json
+++ b/styles/piraeus.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Piraeus",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/porto.json
+++ b/styles/porto.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Porto",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/rio.json
+++ b/styles/rio.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Rio",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/santa-fe.json
+++ b/styles/santa-fe.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Santa Fe",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/thimphu.json
+++ b/styles/thimphu.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Thimphu",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/styles/tokyo.json
+++ b/styles/tokyo.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"title": "Tokyo",
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"color": {
 			"duotone": [

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
-	"version": 2,
+	"version": 3,
 	"customTemplates": [
 		{
 			"name": "blank",


### PR DESCRIPTION
### Problem

The linter is warning that the schema version should be `3`, and when using the theme/styles internally, WordPress is already transforming the version from `2` to `3` after reading the files from disk.

### Solution

Updates the version in all the `theme.json` files for theme and styles.