### PR TITLE
Fixes WPCF7 `input` and `textarea` styles

### DIFF
--- a/assets/css/contact-form-7.css
+++ b/assets/css/contact-form-7.css
@@ -10,6 +10,7 @@
 	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);
 	border-color: inherit;
+	box-sizing: border-box;
 }
 
 .wpcf7-form-control-wrap {
@@ -46,7 +47,9 @@
 		--wp--custom--elements--button--focus--color--background
 	);
 	color: var(--wp--custom--elements--button--focus--color--text);
-	outline-color: var(--wp--custom--elements--button--focus--color--background);
+	outline-color: var(
+		--wp--custom--elements--button--focus--color--background
+	);
 	offset: 2px;
 	outline-width: 1px;
 	outline-offset: 2px;


### PR DESCRIPTION
### Problem

Forms on mobile overflow the screen. See this comment in Slack: https://extendify.slack.com/archives/C02K55ZMK3L/p1735575607366229

### Solution

Add `box-sizing: border-box` to the `input` and `textarea` elements.

## How to Test

Build the theme from this branch/PR, and try to replicate the form overflowing on mobile before this fix and after this fix. 