### PR TITLE
Fix: koulen font with incorrect path

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -528,7 +528,7 @@
 							"fontStretch": "normal",
 							"fontStyle": "normal",
 							"fontWeight": "400",
-							"src": ["file:./assets/fonts/koulen/Koulen-Regular.woff2"]
+							"src": ["file:./assets/fonts/koulen/koulen-regular.woff2"]
 						}
 					],
 					"fontFamily": "\"Koulen\", sans-serif",


### PR DESCRIPTION
## Description

### Issue

Closes [#1317](https://github.com/extendify/company-product/issues/1317)

### Problem

Recently, we changed all font file names to lowercase. However, there is still a request being made for:
`/wp-content/themes/extendable/assets/fonts/koulen/Koulen-Regular.woff2` when the correct path should be: `/wp-content/themes/extendable/assets/fonts/koulen/koulen-regular.woff2`.

This mismatch causes a 404 error when the font is requested.

### Solution

The fix was to rename the font file reference to lowercase in theme.json, ensuring it matches the updated file name.

![Xnip2025-02-25_14-37-14](https://github.com/user-attachments/assets/07b47073-06b1-48b6-9a87-6487502aa000)


## How to Test

1. Go to any page on Editor mode.
2. Select any text and change the font-family to Koulen.
3. Go to live preview and check if font is loading as expected and if browser console does not have more the 404 error.

## Blockages for Merge (if any)

None.
