### PR TITLE
Fix Duotone filter color and adjust header logo

### DIFF
--- a/parts/header.html
+++ b/parts/header.html
@@ -2,17 +2,16 @@
 <div class="wp-block-group alignfull"
 	style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)">
 	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignwide"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group"><!-- wp:site-logo /-->
-
+	<div class="wp-block-group alignwide">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group">
+			<!-- wp:site-logo {"shouldSyncIcon":true} /-->
 			<!-- wp:group -->
 			<div class="wp-block-group">
 				<!-- wp:site-title {"style":{"typography":{"textTransform":"uppercase"}},"fontSize":"medium"} /-->
 			</div>
-			<!-- /wp:group -->
-		</div>
+			<!-- /wp:group --></div>
 		<!-- /wp:group -->
-
 		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group">
 			<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->

--- a/styles/brisbane.json
+++ b/styles/brisbane.json
@@ -26,12 +26,12 @@
 					"name": "Primary and Secondary"
 				},
 				{
-					"colors": ["#ffffff", "#F9F6DE"],
+					"colors": ["#f7fafc", "#F9F6DE"],
 					"slug": "foreground-primary",
 					"name": "Foreground and Primary"
 				},
 				{
-					"colors": ["#204f46", "#fcf8f2"],
+					"colors": ["#2d3f47", "#fcf8f2"],
 					"slug": "tertiary-secondary",
 					"name": "Tertiary and Secondary"
 				},
@@ -41,7 +41,7 @@
 					"name": "Primary and Foreground"
 				},
 				{
-					"colors": ["#f7fafc", "#2d3f47"],
+					"colors": ["#3f5762", "#2d3f47"],
 					"slug": "background-tertiary",
 					"name": "Background and Background Alt"
 				}

--- a/styles/cairo.json
+++ b/styles/cairo.json
@@ -31,7 +31,7 @@
 					"name": "Primary and Foreground"
 				},
 				{
-					"colors": ["#ffffff", "#4F4557"],
+					"colors": ["#393646", "#4F4557"],
 					"slug": "background-tertiary",
 					"name": "Background and Background Alt"
 				}

--- a/styles/colors/bloom.json
+++ b/styles/colors/bloom.json
@@ -29,6 +29,11 @@
 					"colors": ["#014932", "#000000"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffffff", "#FFEFEA"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/brisbane.json
+++ b/styles/colors/brisbane.json
@@ -21,17 +21,17 @@
 					"name": "Secondary"
 				},
 				{
-					"colors": ["#102e43", "#fcf8f2"],
+					"colors": ["#F9F6DE", "#fcf8f2"],
 					"slug": "primary-secondary",
 					"name": "Primary and Secondary"
 				},
 				{
-					"colors": ["#ffffff", "#102e43"],
+					"colors": ["#f7fafc", "#F9F6DE"],
 					"slug": "foreground-primary",
 					"name": "Foreground and Primary"
 				},
 				{
-					"colors": ["#204f46", "#fcf8f2"],
+					"colors": ["#2d3f47", "#fcf8f2"],
 					"slug": "tertiary-secondary",
 					"name": "Tertiary and Secondary"
 				},
@@ -39,6 +39,11 @@
 					"colors": ["#F9F6DE", "#f7fafc"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#3f5762", "#2d3f47"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/cairo.json
+++ b/styles/colors/cairo.json
@@ -29,6 +29,11 @@
 					"colors": ["#F4EEE0", "#ffffff"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#393646", "#4F4557"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/fusion-sky.json
+++ b/styles/colors/fusion-sky.json
@@ -29,6 +29,11 @@
 					"colors": ["#0B51C2", "#000000"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffffff", "#F9FAFE"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/gdansk.json
+++ b/styles/colors/gdansk.json
@@ -29,6 +29,11 @@
 					"colors": ["#f5ac8e", "#fcece8"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#0c0c0b", "#50140d"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [
@@ -62,7 +67,6 @@
 	},
 	"styles": {
 		"blocks": {
-
 			"core/pullquote": {
 				"border": {
 					"color": "var(--wp--preset--color--primary)"

--- a/styles/colors/glasgow.json
+++ b/styles/colors/glasgow.json
@@ -39,6 +39,11 @@
 					"colors": ["#3b2300", "#13100f"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#dbd3ce", "#c6b6ac"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/graphite.json
+++ b/styles/colors/graphite.json
@@ -6,17 +6,17 @@
 		"color": {
 			"duotone": [
 				{
-					"colors": ["#d61935", "#395144"],
+					"colors": ["#292929", "#303030"],
 					"slug": "primary-and-secondary",
 					"name": "Primary and secondary"
 				},
 				{
-					"colors": ["#d61935", "#ffeae6"],
+					"colors": ["#292929", "#E9E8E6"],
 					"slug": "primary-and-tertiary",
 					"name": "Primary and tertiary"
 				},
 				{
-					"colors": ["#395144", "#d61935"],
+					"colors": ["#303030", "#292929"],
 					"slug": "secondary-and-primary",
 					"name": "Secondary and primary"
 				},
@@ -26,9 +26,14 @@
 					"name": "Foreground and background"
 				},
 				{
-					"colors": ["#014630", "#000000"],
+					"colors": ["#292929", "#000000"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffffff", "#E9E8E6"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/hong-kong.json
+++ b/styles/colors/hong-kong.json
@@ -6,12 +6,12 @@
 		"color": {
 			"duotone": [
 				{
-					"colors": ["#c6120d", "#f1e3e1"],
+					"colors": ["#c6120d", "#ffebe9"],
 					"slug": "foreground-and-background",
 					"name": "Foreground and background"
 				},
 				{
-					"colors": ["#f1e3e1", "#c6120d"],
+					"colors": ["#ffebe9", "#c6120d"],
 					"slug": "background-and-foreground",
 					"name": "Background and foreground"
 				},
@@ -21,9 +21,14 @@
 					"name": "Primary and secondary"
 				},
 				{
-					"colors": ["#A30026", "#a40e26"],
+					"colors": ["#860000", "#a40e26"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffebe9", "#ffffff"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [
@@ -79,7 +84,6 @@
 	},
 	"styles": {
 		"blocks": {
-
 			"core/pullquote": {
 				"border": {
 					"color": "var(--wp--preset--color--primary)"

--- a/styles/colors/kampala.json
+++ b/styles/colors/kampala.json
@@ -24,6 +24,11 @@
 					"colors": ["#0B119C", "#010110"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#f7f9fe", "#ffffff"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/lagoon.json
+++ b/styles/colors/lagoon.json
@@ -29,6 +29,11 @@
 					"colors": ["#13607E", "#292929"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffffff", "#faf7f8"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [
@@ -57,7 +62,7 @@
 					"color": "#faf7f8",
 					"name": "Tertiary"
 				},
-                {
+				{
 					"slug": "foreground-alt",
 					"color": "#292929",
 					"name": "Foreground Alt"
@@ -71,7 +76,7 @@
 		},
 		"elements": {
 			"heading": {
-                "color": {
+				"color": {
 					"text": "var(--wp--preset--color--foreground)"
 				}
 			}

--- a/styles/colors/odesa.json
+++ b/styles/colors/odesa.json
@@ -11,7 +11,7 @@
 					"name": "Foreground and background"
 				},
 				{
-					"colors": ["#ffffff", "#ffc401"],
+					"colors": ["#ffffff", "#070f79"],
 					"slug": "background-and-primary",
 					"name": "Background and primary"
 				},
@@ -21,14 +21,19 @@
 					"name": "Background and secondary"
 				},
 				{
-					"colors": ["#ffc401", "#f3c8cf"],
+					"colors": ["#070f79", "#f3c8cf"],
 					"slug": "primary-and-secondary",
 					"name": "Primary and secondary"
 				},
 				{
-					"colors": ["#ffc401", "#0b0449"],
+					"colors": ["#070f79", "#0b0449"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffffff", "#fcf9f5"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/onyx.json
+++ b/styles/colors/onyx.json
@@ -26,9 +26,14 @@
 					"name": "Foreground and background"
 				},
 				{
-					"colors": ["#FFFCFC", "#FFFCFC"],
+					"colors": ["#FFFFFF", "#FFFCFC"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#17181A", "#000000"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/orange.json
+++ b/styles/colors/orange.json
@@ -24,6 +24,11 @@
 					"colors": ["#DE3707", "#1A1A1A"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffffff", "#f2f3f5"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/piraeus.json
+++ b/styles/colors/piraeus.json
@@ -39,6 +39,11 @@
 					"colors": ["#A89F84", "#ffffff"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#272725", "#32322D"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/porto.json
+++ b/styles/colors/porto.json
@@ -24,6 +24,11 @@
 					"colors": ["#854836", "#4D4848"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#F8FAF9", "#F8ECEA"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/rio.json
+++ b/styles/colors/rio.json
@@ -29,6 +29,11 @@
 					"colors": ["#174c2f", "#010101"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#fbfbfb", "#A8E1FF"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/santa-fe.json
+++ b/styles/colors/santa-fe.json
@@ -26,9 +26,14 @@
 					"name": "Primary and tertiary"
 				},
 				{
-					"colors": ["#1f033b", "#111111"],
+					"colors": ["#2c0453", "#111111"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffffff", "#f0ede4"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/thimphu.json
+++ b/styles/colors/thimphu.json
@@ -29,6 +29,16 @@
 					"colors": ["#3a312e", "#f24139"],
 					"slug": "secondary-foreground",
 					"name": "secondary and Foreground"
+				},
+				{
+					"colors": ["#f24139", "#f24139"],
+					"slug": "primary-foreground",
+					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffebcc", "#ffdda6"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/colors/tokyo.json
+++ b/styles/colors/tokyo.json
@@ -29,6 +29,11 @@
 					"colors": ["#d61935", "#010101"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
+				},
+				{
+					"colors": ["#ffffff", "#ffeae6"],
+					"slug": "background-tertiary",
+					"name": "Background and Background Alt"
 				}
 			],
 			"palette": [

--- a/styles/graphite.json
+++ b/styles/graphite.json
@@ -6,17 +6,17 @@
 		"color": {
 			"duotone": [
 				{
-					"colors": ["#d61935", "#395144"],
+					"colors": ["#292929", "#303030"],
 					"slug": "primary-and-secondary",
 					"name": "Primary and secondary"
 				},
 				{
-					"colors": ["#d61935", "#ffeae6"],
+					"colors": ["#292929", "#E9E8E6"],
 					"slug": "primary-and-tertiary",
 					"name": "Primary and tertiary"
 				},
 				{
-					"colors": ["#395144", "#d61935"],
+					"colors": ["#303030", "#292929"],
 					"slug": "secondary-and-primary",
 					"name": "Secondary and primary"
 				},
@@ -26,7 +26,7 @@
 					"name": "Foreground and background"
 				},
 				{
-					"colors": ["#014630", "#000000"],
+					"colors": ["#292929", "#000000"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
 				},

--- a/styles/hong-kong.json
+++ b/styles/hong-kong.json
@@ -6,12 +6,12 @@
 		"color": {
 			"duotone": [
 				{
-					"colors": ["#c6120d", "#f1e3e1"],
+					"colors": ["#c6120d", "#ffebe9"],
 					"slug": "foreground-and-background",
 					"name": "Foreground and background"
 				},
 				{
-					"colors": ["#f1e3e1", "#c6120d"],
+					"colors": ["#ffebe9", "#c6120d"],
 					"slug": "background-and-foreground",
 					"name": "Background and foreground"
 				},
@@ -21,7 +21,7 @@
 					"name": "Primary and secondary"
 				},
 				{
-					"colors": ["#A30026", "#a40e26"],
+					"colors": ["#860000", "#a40e26"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
 				},

--- a/styles/odesa.json
+++ b/styles/odesa.json
@@ -11,7 +11,7 @@
 					"name": "Foreground and background"
 				},
 				{
-					"colors": ["#ffffff", "#ffc401"],
+					"colors": ["#ffffff", "#070f79"],
 					"slug": "background-and-primary",
 					"name": "Background and primary"
 				},
@@ -21,12 +21,12 @@
 					"name": "Background and secondary"
 				},
 				{
-					"colors": ["#ffc401", "#f3c8cf"],
+					"colors": ["#070f79", "#f3c8cf"],
 					"slug": "primary-and-secondary",
 					"name": "Primary and secondary"
 				},
 				{
-					"colors": ["#ffc401", "#0b0449"],
+					"colors": ["#070f79", "#0b0449"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
 				},

--- a/styles/onyx.json
+++ b/styles/onyx.json
@@ -26,7 +26,7 @@
 					"name": "Foreground and background"
 				},
 				{
-					"colors": ["#FFFCFC", "#FFFCFC"],
+					"colors": ["#FFFFFF", "#FFFCFC"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
 				},

--- a/styles/santa-fe.json
+++ b/styles/santa-fe.json
@@ -26,7 +26,7 @@
 					"name": "Primary and tertiary"
 				},
 				{
-					"colors": ["#1f033b", "#111111"],
+					"colors": ["#2c0453", "#111111"],
 					"slug": "primary-foreground",
 					"name": "Primary and Foreground"
 				},

--- a/styles/thimphu.json
+++ b/styles/thimphu.json
@@ -31,6 +31,11 @@
 					"name": "secondary and Foreground"
 				},
 				{
+					"colors": ["#f24139", "#f24139"],
+					"slug": "primary-foreground",
+					"name": "Primary and Foreground"
+				},
+				{
 					"colors": ["#ffebcc", "#ffdda6"],
 					"slug": "background-tertiary",
 					"name": "Background and Background Alt"


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/extendify/company-product/issues/1345#issuecomment-2722263520)

The problem was that in the odesa.json style variation, the primary-foreground duotone filter had an incorrect primary color.