### PR TITLE
Feat: add new CSS rule to new logo file name pattern

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -157,7 +157,7 @@ add_action( 'init', 'extendable_register_pattern_categories', 9 );
 
 /**
  * Enqueue dynamic CSS for primary-foreground duotone filter.
- * 
+ *
  * Ensure default logo works well on light and dark backgrounds
  *
  * @since Extendable 2.0.11
@@ -177,7 +177,8 @@ function extendable_enqueue_dynamic_duotone_css() {
     }
     list( $r, $g, $b ) = array_map( fn( $c ) => hexdec( $c ) / 255, sscanf( $primary_color, "#%02x%02x%02x" ) );
     $css = "
-        .wp-block-site-logo img[src*='extendify-demo-'] {
+        .wp-block-site-logo img[src*='extendify-demo-'],
+		.wp-block-site-logo img[src*='ext-custom-logo-'] {
             filter: url('data:image/svg+xml,<svg xmlns=\"http://www.w3.org/2000/svg\"><filter id=\"solid-color\"><feColorMatrix color-interpolation-filters=\"sRGB\" type=\"matrix\" values=\"0 0 0 0 {$r} 0 0 0 0 {$g} 0 0 0 0 {$b} 0 0 0 1 0\"/></filter></svg>#solid-color') !important;
         }
     ";

--- a/style.css
+++ b/style.css
@@ -111,7 +111,7 @@ nav .wp-block-pages-list__item.wp-block-navigation-item.menu-item-home {
 .wp-element-button {
 	transition: background-color 0.15s ease;
 }
-.wp-block-button .wp-block-button__link.is-style-outline:not(.has-background):hover, 
+.wp-block-button .wp-block-button__link.is-style-outline:not(.has-background):hover,
 .wp-block-button.is-style-outline>.wp-block-button__link:not(.has-background):hover {
 	background-color: rgba(159, 159, 159, 0.2);
 }
@@ -171,7 +171,8 @@ blockquote:is(.is-style-plain) {
 
 /* Ensure default logo works well on light and dark backgrounds
 ----------------------------------------------------------*/
-.wp-block-site-logo img[src*="extendify-demo-"] {
+.wp-block-site-logo img[src*="extendify-demo-"],
+.wp-block-site-logo img[src*="ext-custom-logo-"] {
 	filter: var(--wp--preset--duotone--primary-foreground);
 }
 
@@ -206,7 +207,7 @@ input, textarea {
 /*
  * Matching input with outline button style.
  */
-:where(.wp-block-post-comments-form) input:not([type=submit]), 
+:where(.wp-block-post-comments-form) input:not([type=submit]),
 :where(.wp-block-post-comments-form) textarea {
 	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--foreground);


### PR DESCRIPTION
## Description

### Issue

https://github.com/extendify/company-product/issues/1350

### Problem

We are implementing a new patter to logo file name generated by AI. So we need update the CSS rule to match this new pattern.

Related to: https://github.com/extendify/extendify-sdk/pull/2638#discussion_r2055058042

### Solution

Add new rule pattern and keep the current to ensure backwards compatibility.

## How to Test

Use a logo with an image with file name pattern `ext-custom-logo-` and check if style filters will be applied.

## Blockages for Merge (if any)

None.
