### PR TITLE
Fix overlay headers wrapped by sticky-header

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -4,11 +4,12 @@
 	const header = document.querySelector( 'header.wp-block-template-part' );
 	if ( ! header ) return;
 
-	// Temporary: when our header is wrapped in another <header> (e.g. via the
-	// no-title-sticky-header.html template part), strip the overlay-system
-	// classes so none of our CSS rules fire on it — the outer wrapper handles
-	// layout natively. Remove once the upstream template stops wrapping.
-	if ( header.parentElement?.tagName === 'HEADER' ) {
+	// Temporary: when our header is rendered inside a wrapping template part
+	// that opts in by carrying .ext-header-wrapper (e.g. no-title-sticky-
+	// header.html in the agent plugin), strip the overlay-system classes so
+	// none of our CSS rules fire — the outer wrapper handles layout natively.
+	// Remove once the upstream template stops wrapping.
+	if ( header.closest( '.ext-header-wrapper' ) ) {
 		const overlay = header.querySelector( '.ext-header-overlay' );
 		if ( overlay ) {
 			overlay.classList.remove(

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -4,6 +4,23 @@
 	const header = document.querySelector( 'header.wp-block-template-part' );
 	if ( ! header ) return;
 
+	// Temporary: when our header is wrapped in another <header> (e.g. via the
+	// no-title-sticky-header.html template part), strip the overlay-system
+	// classes so none of our CSS rules fire on it — the outer wrapper handles
+	// layout natively. Remove once the upstream template stops wrapping.
+	if ( header.parentElement?.tagName === 'HEADER' ) {
+		const overlay = header.querySelector( '.ext-header-overlay' );
+		if ( overlay ) {
+			overlay.classList.remove(
+				'ext-header-overlay',
+				'ext-header-glass',
+				'ext-header-sticky',
+				'ext-header-sticky--floating-pill',
+				'ext-header--dark'
+			);
+		}
+	}
+
 	const findHero = () => document.querySelector(
 		'.entry-content > .ext-hero-section.ext-hero-section--full-screen:first-child'
 	);

--- a/style.css
+++ b/style.css
@@ -1089,3 +1089,15 @@ body.admin-bar:has(.entry-content > .ext-hero-section.ext-hero-section--full-scr
 .ext-header-glass[class*="is-style-ext-preset--"] {
 	background-image: none !important;
 }
+
+/* Temporary: a few template parts (e.g. no-title-sticky-header.html) wrap our
+   header in another sticky <header>. Scope the fix to the three new headers
+   (atlas-beacon, catalina-skyline, ceadar-peak) — they're the only ones
+   using .ext-header-overlay, so older headers that intentionally rely on
+   the wrapper's positioning aren't affected. display: contents removes the
+   wrapper from layout entirely so its bg/border/sticky/box-shadow/
+   wp-container-* styles don't apply. Remove once the upstream template
+   stops wrapping. */
+header:has(> header.wp-block-template-part :where(.ext-header-overlay)) {
+	display: contents;
+}

--- a/templates/no-title-sticky-header.html
+++ b/templates/no-title-sticky-header.html
@@ -1,6 +1,6 @@
-<!-- wp:group {"tagName":"header","metadata":{"name":"Sticky Header"},"style":{"position":{"type":"sticky","top":"0px"},"border":{"bottom":{"color":"#8585851f","width":"1px"},"top":[],"right":[],"left":[]},"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"backgroundColor":"background","layout":{"type":"default"}} -->
+<!-- wp:group {"tagName":"header","metadata":{"name":"Sticky Header"},"className":"ext-header-wrapper","style":{"position":{"type":"sticky","top":"0px"},"border":{"bottom":{"color":"#8585851f","width":"1px"},"top":[],"right":[],"left":[]},"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}},"backgroundColor":"background","layout":{"type":"default"}} -->
 <header
-	class="wp-block-group has-background-background-color has-background"
+	class="wp-block-group ext-header-wrapper has-background-background-color has-background"
 	style="
 		border-bottom-color: #8585851f;
 		border-bottom-width: 1px;


### PR DESCRIPTION
This resolves [this issue](https://extendify.slack.com/archives/C07S030UWSJ/p1779758315034619): 