### PR TITLE
Fix block validation error in single-product template

### DIFF
--- a/templates/single-product.html
+++ b/templates/single-product.html
@@ -6,8 +6,8 @@
 	style="
 		margin-top: 0;
 		margin-bottom: 0;
-		padding-top: var(--wp--preset--spacing--50);
-		padding-bottom: var(--wp--preset--spacing--50);
+		padding-top: var(--wp--preset--spacing--60);
+		padding-bottom: var(--wp--preset--spacing--60);
 	"
 >
 	<!-- wp:woocommerce/breadcrumbs /-->


### PR DESCRIPTION
The group declared padding spacing|60 in its block attributes
but the inline style rendered spacing|50, so Gutenberg flagged
"this block contains unexpected or invalid content." Align the inline
style to 60 to match the attribute.