### PR TITLE
Stop pinning transform:none on blocks after their entrance animation

### DIFF
--- a/assets/css/animations.css
+++ b/assets/css/animations.css
@@ -39,7 +39,6 @@
 
 .ext-animate[data-ext-animated] {
     opacity: 1 !important;
-    transform: none !important;
     animation: none !important;
 }
 


### PR DESCRIPTION
When a block finished its entrance animation, the theme locked it flat. Any tilt, skew, or rotation added afterwards — including one the AI Agent adds for you — looked right while you were editing and then vanished on the next page load. The lock turned out to be unnecessary, so it's gone. Entrance animations behave exactly as before.

- Custom opacity and custom animations on an animated block are still overridden. Kevin flagged that as a separate follow-up (wrapping the selector in `:where()`), deliberately not in this PR.

## How to test

On a site with animations turned on, give an animated block a rotation through custom CSS — in the block editor's Additional CSS panel, or by asking the Agent to tilt a heading — then reload the page. The tilt should still be there, and the block should still fade in on scroll.

Closes extendify/company-product#2278
